### PR TITLE
Create a Docker client plugin system and add a LocalClient based on a…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Documentation for the Siren prompt injection research tool.
 ## Getting Started
 
 - **[Configuration Guide](configuration.md)** - Basic usage and configuration
+- **[Docker Backends](docker_backends.md)** - Running with Local Docker or DES (Docker Execution Service)
 - **[Usage Limits](usage_limits.md)** - Resource limits and cost controls
 - **[Plugins](plugins/README.md)** - Adding custom agents, attacks, environments
 

--- a/docs/docker_backends.md
+++ b/docs/docker_backends.md
@@ -1,0 +1,287 @@
+# Docker Execution Backends
+
+The Prompt Siren Workbench supports two Docker execution backends for running containerized tasks: **Local Docker** and **DES (Docker Execution Service)**.
+
+## Overview
+
+Docker execution backends handle the creation, management, and execution of Docker containers for sandbox environments. The backend you choose determines where and how your containers run.
+
+### Available Backends
+
+1. **Local Docker** - Runs containers on your local machine using the Docker daemon
+2. **DES (Docker Execution Service)** - Runs containers on a remote VM managed by Meta's internal service
+
+## Local Docker Backend
+
+The local Docker backend executes containers directly on your machine using the Docker daemon.
+
+### Requirements
+
+- Docker installed and running on your machine
+- Docker socket accessible (typically `/var/run/docker.sock`)
+- `DOCKER_HOST` environment variable set in your `.env` file
+
+### Setup
+
+1. **Install Docker** (if not already installed):
+   ```bash
+   # On devserver, Docker is typically pre-installed
+   docker --version
+   ```
+
+2. **Configure environment** in `.env`:
+   ```bash
+   DOCKER_HOST="unix:///var/run/docker.sock"
+   ```
+
+3. **Verify Docker is running**:
+   ```bash
+   docker ps
+   ```
+
+### Usage
+
+Local Docker is the default backend and requires no special configuration:
+
+```bash
+# Run with local Docker (default)
+with-proxy uv run --env-file .env prompt-siren run benign +dataset=swebench
+
+# Or explicitly specify
+with-proxy uv run --env-file .env prompt-siren run benign +dataset=swebench \
+  sandbox_manager.config.docker_client=local
+```
+
+### Advantages
+
+- **Fast**: No network latency, containers run locally
+- **Easy debugging**: Direct access to containers via `docker` CLI
+- **No quotas**: Limited only by your machine's resources
+
+### Limitations
+
+- Requires Docker daemon running
+- Limited by local machine resources
+- Cannot run on machines without Docker
+
+## DES (Docker Execution Service) Backend
+
+DES is Meta's internal service for running Docker containers on remote VMs. Useful when you don't have access to a local Docker daemon or need isolated execution.
+
+### Requirements
+
+- Access to Meta's internal network
+- `des_exec` binary available in your PATH
+- No local Docker installation required
+
+### Setup
+
+1. **Verify DES access**:
+   ```bash
+   which des_exec
+   # Should show path to des_exec binary
+   ```
+
+2. **No additional environment variables needed** - DES handles authentication automatically
+
+### Usage
+
+Specify DES as the Docker client backend using Hydra configuration:
+
+```bash
+# Basic DES usage
+with-proxy uv run --env-file .env prompt-siren run benign +dataset=swebench \
+  sandbox_manager.config.docker_client=des
+
+# Configure session timeout (in seconds)
+with-proxy uv run --env-file .env prompt-siren run benign +dataset=swebench \
+  sandbox_manager.config.docker_client=des \
+  sandbox_manager.config.des_session_timeout=7200
+
+# Pre-load specific Docker images on the VM
+with-proxy uv run --env-file .env prompt-siren run benign +dataset=swebench \
+  sandbox_manager.config.docker_client=des \
+  'sandbox_manager.config.des_docker_images=["vmvm-registry.fbinfra.net/debian:bookworm-slim","python:3.12"]'
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `sandbox_manager.config.docker_client` | string | `"local"` | Docker client backend to use (`"local"` or `"des"`) |
+| `sandbox_manager.config.des_session_timeout` | int | `3600` | DES session timeout in seconds |
+| `sandbox_manager.config.des_docker_images` | list[str] | `[]` | Docker images to pre-load on the DES VM |
+
+### Advantages
+
+- **No local Docker required**: Runs on remote VMs
+- **Isolated execution**: Each session gets a fresh VM
+- **Managed infrastructure**: Meta handles VM provisioning and cleanup
+
+### Limitations
+
+- **Network latency**: Remote execution adds overhead
+- **Session timeouts**: Long-running tasks may need increased timeout
+- **Image pre-loading**: Must specify images to make available on VM
+
+## Hydra Configuration
+
+You can set the Docker backend in your Hydra configuration file or via command-line overrides.
+
+### In Configuration File
+
+Create or modify `config.yaml`:
+
+```yaml
+defaults:
+  - _self_
+  - dataset: swebench
+
+sandbox_manager:
+  type: local-docker
+  config:
+    docker_client: des  # Use DES backend
+    des_session_timeout: 7200
+    des_docker_images:
+      - vmvm-registry.fbinfra.net/debian:bookworm-slim
+      - python:3.12
+```
+
+Then run without needing overrides:
+
+```bash
+with-proxy uv run --env-file .env prompt-siren run benign --config-dir=./config
+```
+
+### Via Command-Line Overrides
+
+Override the backend at runtime:
+
+```bash
+# Switch from local to DES
+with-proxy uv run --env-file .env prompt-siren run benign +dataset=swebench \
+  sandbox_manager.config.docker_client=des
+
+# Switch from DES to local
+with-proxy uv run --env-file .env prompt-siren run benign +dataset=swebench \
+  sandbox_manager.config.docker_client=local
+```
+
+## End-to-End Example
+
+Here's a complete example of running SWE-bench with both backends:
+
+### Local Docker
+
+```bash
+# 1. Set up environment
+cat > .env <<EOF
+DOCKER_HOST="unix:///var/run/docker.sock"
+AZURE_OPENAI_ENDPOINT="https://your-endpoint.azure-api.net"
+AZURE_OPENAI_API_KEY="your-key"
+OPENAI_API_VERSION="2025-04-01-preview"
+EOF
+
+# 2. Verify Docker is running
+docker ps
+
+# 3. Run with local Docker
+with-proxy uv run --env-file .env prompt-siren run benign +dataset=swebench \
+  agent.config.model=azure:gpt-4o \
+  'dataset.config.instance_ids=["django__django-11179"]'
+```
+
+### DES (Docker Execution Service)
+
+```bash
+# 1. Set up environment (no DOCKER_HOST needed)
+cat > .env <<EOF
+AZURE_OPENAI_ENDPOINT="https://your-endpoint.azure-api.net"
+AZURE_OPENAI_API_KEY="your-key"
+OPENAI_API_VERSION="2025-04-01-preview"
+EOF
+
+# 2. Verify DES access
+which des_exec
+
+# 3. Run with DES
+with-proxy uv run --env-file .env prompt-siren run benign +dataset=swebench \
+  sandbox_manager.config.docker_client=des \
+  sandbox_manager.config.des_session_timeout=7200 \
+  'sandbox_manager.config.des_docker_images=["vmvm-registry.fbinfra.net/debian:bookworm-slim"]' \
+  agent.config.model=azure:gpt-4o \
+  'dataset.config.instance_ids=["django__django-11179"]'
+```
+
+## Troubleshooting
+
+### Local Docker Issues
+
+**Problem**: `Cannot connect to Docker daemon`
+```bash
+# Solution: Verify Docker is running
+docker ps
+
+# Check DOCKER_HOST is set correctly
+echo $DOCKER_HOST
+```
+
+**Problem**: `Permission denied` accessing Docker socket
+```bash
+# Solution: Check socket permissions
+ls -l /var/run/docker.sock
+
+# May need to add your user to docker group (requires logout/login)
+sudo usermod -aG docker $USER
+```
+
+### DES Issues
+
+**Problem**: `des_exec: command not found`
+```bash
+# Solution: Verify des_exec is in PATH
+which des_exec
+
+# If not found, check if it's installed
+feature install des_exec  # Or appropriate installation command
+```
+
+**Problem**: `DES session timeout`
+```bash
+# Solution: Increase session timeout
+sandbox_manager.config.des_session_timeout=7200  # 2 hours
+```
+
+**Problem**: `Docker image not found on DES VM`
+```bash
+# Solution: Pre-load images
+sandbox_manager.config.des_docker_images='["vmvm-registry.fbinfra.net/debian:bookworm-slim","python:3.12"]'
+```
+
+## Plugin System
+
+Both Local Docker and DES are implemented as plugins using the Docker client registry system. You can create custom Docker client plugins by:
+
+1. Implementing the `AbstractDockerClient` protocol
+2. Creating a factory function
+3. Registering via entry points
+
+See [custom_components.md](custom_components.md) for details on creating custom plugins.
+
+## Performance Considerations
+
+### Local Docker
+- **Startup time**: Fast (~1-2 seconds per container)
+- **Execution**: No network latency
+- **Best for**: Development, testing, small datasets
+
+### DES
+- **Startup time**: Slower (~30-60 seconds for VM provisioning)
+- **Execution**: Network latency for all operations
+- **Best for**: Production, large-scale runs, no local Docker available
+
+## See Also
+
+- [Sandbox Manager Documentation](sandbox_manager.md) - General sandbox manager concepts
+- [Configuration Guide](configuration.md) - Hydra configuration details
+- [Custom Components](custom_components.md) - Creating custom plugins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ local-docker = "prompt_siren.sandbox_managers.docker:create_docker_sandbox_manag
 bedrock = "prompt_siren.providers.bedrock:BedrockProvider"
 llama = "prompt_siren.providers.llama:LlamaProvider"
 
+[project.entry-points."prompt_siren.docker_clients"]
+local = "prompt_siren.sandbox_managers.docker.plugins.local_client:create_local_docker_client"
+
 [project.optional-dependencies]
 agentdojo = ["agentdojo>=0.1.35"]
 swebench = ["swebench", "jinja2>=3.1.6"]

--- a/src/prompt_siren/sandbox_managers/docker/abstract_client.py
+++ b/src/prompt_siren/sandbox_managers/docker/abstract_client.py
@@ -1,0 +1,235 @@
+"""Abstract Docker client interface for supporting multiple execution backends.
+
+This module provides abstractions for Docker operations that can be implemented
+by different backends (local Docker via aiodocker, or remote Docker via DES).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
+from typing import Any
+
+from ..abstract import ExecOutput
+
+
+class AbstractContainer(ABC):
+    """Abstract interface for Docker containers."""
+
+    @abstractmethod
+    async def start(self) -> None:
+        """Start the container."""
+        ...
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Stop the container."""
+        ...
+
+    @abstractmethod
+    async def delete(self) -> None:
+        """Delete the container."""
+        ...
+
+    @abstractmethod
+    async def show(self) -> dict[str, Any]:
+        """Get container details.
+
+        Returns:
+            Dict with container information including Id, State, Config, HostConfig
+        """
+        ...
+
+    @abstractmethod
+    async def exec(
+        self,
+        cmd: list[str],
+        stdin: str | bytes | None,
+        user: str,
+        environment: dict[str, str] | None,
+        workdir: str | None,
+        timeout: int,
+    ) -> ExecOutput:
+        """Execute a command in the container.
+
+        Args:
+            cmd: Command to execute (already in bash -c format)
+            stdin: Optional stdin data to pass to the command
+            user: User to run as
+            environment: Environment variables
+            workdir: Working directory
+            timeout: Timeout in seconds
+
+        Returns:
+            ExecOutput containing stdout/stderr chunks and exit code
+        """
+        ...
+
+    @abstractmethod
+    async def log(self, stdout: bool, stderr: bool) -> list[str]:
+        """Get container logs.
+
+        Args:
+            stdout: Include stdout
+            stderr: Include stderr
+
+        Returns:
+            List of log lines
+        """
+        ...
+
+    @abstractmethod
+    async def commit(self, repository: str, tag: str) -> None:
+        """Commit container to an image.
+
+        Args:
+            repository: Repository name
+            tag: Image tag
+        """
+        ...
+
+
+class AbstractNetwork(ABC):
+    """Abstract interface for Docker networks."""
+
+    @abstractmethod
+    async def show(self) -> dict[str, Any]:
+        """Get network details.
+
+        Returns:
+            Dict with network information including Id, Driver, Internal
+        """
+        ...
+
+    @abstractmethod
+    async def delete(self) -> None:
+        """Delete the network."""
+        ...
+
+
+class AbstractDockerClient(ABC):
+    """Abstract Docker client interface.
+
+    This interface provides all Docker operations needed by the workbench,
+    abstracting away the underlying implementation (local aiodocker or remote DES).
+    """
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Close the client and clean up resources."""
+        ...
+
+    # Image operations
+
+    @abstractmethod
+    async def inspect_image(self, tag: str) -> dict[str, Any]:
+        """Inspect an image.
+
+        Args:
+            tag: Image tag
+
+        Returns:
+            Image details
+
+        Raises:
+            DockerClientError: If image doesn't exist
+        """
+        ...
+
+    @abstractmethod
+    async def pull_image(self, tag: str) -> None:
+        """Pull an image from registry.
+
+        Args:
+            tag: Image tag to pull
+        """
+        ...
+
+    @abstractmethod
+    async def build_image(
+        self,
+        context_path: str,
+        tag: str,
+        dockerfile_path: str | None = None,
+        buildargs: dict[str, str] | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Build an image from a build context directory.
+
+        The implementation handles creating tar archives and transferring files
+        as needed for the specific backend (local or remote).
+
+        Args:
+            context_path: Path to the build context directory
+            tag: Tag for built image
+            dockerfile_path: Path to Dockerfile relative to context (defaults to "Dockerfile")
+            buildargs: Build arguments
+
+        Yields:
+            Build log entries (dicts with "stream", "error", etc.)
+        """
+        # This is an abstract async generator - implementations must yield log entries
+        yield {}  # type: ignore[unreachable]
+        ...
+
+    @abstractmethod
+    async def delete_image(self, tag: str, force: bool = False) -> None:
+        """Delete an image.
+
+        Args:
+            tag: Image tag to delete
+            force: Force deletion
+        """
+        ...
+
+    # Container operations
+
+    @abstractmethod
+    async def create_container(self, config: dict[str, Any], name: str) -> AbstractContainer:
+        """Create a container.
+
+        Args:
+            config: Container configuration
+            name: Container name
+
+        Returns:
+            Container instance
+        """
+        ...
+
+    @abstractmethod
+    async def get_container(self, container_id: str) -> AbstractContainer:
+        """Get a container by ID.
+
+        Args:
+            container_id: Container ID
+
+        Returns:
+            Container instance
+        """
+        ...
+
+    # Network operations
+
+    @abstractmethod
+    async def create_network(self, config: dict[str, Any]) -> AbstractNetwork:
+        """Create a network.
+
+        Args:
+            config: Network configuration
+
+        Returns:
+            Network instance
+        """
+        ...
+
+    @abstractmethod
+    async def get_network(self, network_id: str) -> AbstractNetwork:
+        """Get a network by ID.
+
+        Args:
+            network_id: Network ID
+
+        Returns:
+            Network instance
+        """
+        ...

--- a/src/prompt_siren/sandbox_managers/docker/client_registry.py
+++ b/src/prompt_siren/sandbox_managers/docker/client_registry.py
@@ -1,0 +1,65 @@
+"""Docker client registry for managing Docker client plugins.
+
+This module provides a registry system for Docker client implementations,
+allowing different backends (local Docker, DES, etc.) to be registered and
+discovered via entry points.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeAlias
+
+from ...registry_base import BaseRegistry
+from .abstract_client import AbstractDockerClient
+
+# Type alias for Docker client factory functions (no config needed)
+DockerClientFactory: TypeAlias = Callable[[], AbstractDockerClient]
+
+# Create a global Docker client registry instance using BaseRegistry
+docker_client_registry = BaseRegistry[AbstractDockerClient, None](
+    "docker_client", "prompt_siren.docker_clients"
+)
+
+
+def register_docker_client(client_name: str, factory: DockerClientFactory) -> None:
+    """Register a Docker client with its factory function.
+
+    Args:
+        client_name: Name of the Docker client (e.g., "local", "des").
+                    This name is used to identify which client to use.
+        factory: Function that takes no arguments and returns an AbstractDockerClient instance
+
+    Raises:
+        ValueError: If the client name is already registered
+
+    Example:
+        >>> def create_my_client() -> AbstractDockerClient:
+        ...     return MyDockerClient()
+        >>> register_docker_client("my-client", create_my_client)
+    """
+    docker_client_registry.register(client_name, factory, config_class=None)
+
+
+def get_docker_client(client_name: str) -> AbstractDockerClient:
+    """Get a Docker client instance by name.
+
+    Args:
+        client_name: Name of the registered Docker client
+
+    Returns:
+        AbstractDockerClient instance
+
+    Raises:
+        KeyError: If the client name is not registered
+    """
+    return docker_client_registry.create_component(client_name, config=None, context=None)
+
+
+def get_registered_docker_clients() -> list[str]:
+    """Get list of all registered Docker client names.
+
+    Returns:
+        List of registered client names
+    """
+    return docker_client_registry.list_names()

--- a/src/prompt_siren/sandbox_managers/docker/contexts.py
+++ b/src/prompt_siren/sandbox_managers/docker/contexts.py
@@ -4,29 +4,24 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
-try:
-    import aiodocker
-    from aiodocker.containers import DockerContainer
-except ImportError as e:
-    raise ImportError(
-        "Docker sandbox manager requires the 'docker' optional dependency. "
-        "Install with: pip install 'prompt-siren[docker]'"
-    ) from e
-
 from ..sandbox_state import ContainerID, SandboxState
 from ..sandbox_task_setup import ContainerSetup, TaskSetup
+from .abstract_client import AbstractContainer, AbstractDockerClient
 from .image_cache import ImageCache
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
 class ContainerInfo:
     """Information about a tracked container."""
 
-    container: DockerContainer
+    container: AbstractContainer
     temp_image: str | None = None  # Temporary image created during cloning
 
 
@@ -43,7 +38,7 @@ class BatchState:
     """
 
     batch_id: str
-    docker_client: aiodocker.Docker
+    docker_client: AbstractDockerClient
     image_cache: ImageCache
     contexts: dict[str, TaskSandboxContext] = field(default_factory=dict)
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
@@ -228,7 +223,7 @@ class TaskSandboxContext:
                 "Internal": False,
             }
 
-        network = await self.batch_state.docker_client.networks.create(config=network_config)
+        network = await self.batch_state.docker_client.create_network(config=network_config)
         network_info = await network.show()
         return network_info["Id"]
 
@@ -242,7 +237,7 @@ class TaskSandboxContext:
             New network ID
         """
         # Get source network config
-        source_network = await self.batch_state.docker_client.networks.get(source_network_id)
+        source_network = await self.batch_state.docker_client.get_network(source_network_id)
         source_info = await source_network.show()
 
         # Create new network with same config
@@ -253,7 +248,7 @@ class TaskSandboxContext:
             "Internal": source_info.get("Internal", False),
         }
 
-        network = await self.batch_state.docker_client.networks.create(config=network_config)
+        network = await self.batch_state.docker_client.create_network(config=network_config)
         network_info = await network.show()
         return network_info["Id"]
 
@@ -275,10 +270,16 @@ class TaskSandboxContext:
         Returns:
             Container ID
         """
+        logger.debug(
+            f"Creating container for task_id={task_id}, container_name={container_setup.name}, "
+            f"network_id={network_id}, network_enabled={network_enabled}"
+        )
+
         # Get image tag from cache
         image_tag = await self.batch_state.image_cache.get_image_for_container(
             container_setup, task_id
         )
+        logger.debug(f"Retrieved image tag from cache: {image_tag}")
 
         # Build container config
         config = self._build_container_config(
@@ -287,6 +288,7 @@ class TaskSandboxContext:
             network_id=network_id,
             network_enabled=network_enabled,
         )
+        logger.debug(f"Built container config: {config}")
 
         # Generate unique container name
         safe_task_id = task_id.replace(":", "-").replace("/", "-")
@@ -295,26 +297,56 @@ class TaskSandboxContext:
             f"{self.batch_state.batch_id}-{self.execution_id}-"
             f"{container_setup.name}-{safe_task_id}-{unique_suffix}"
         )
+        logger.debug(f"Generated container name: {container_name}")
 
         # Create and start container
-        container = await self.batch_state.docker_client.containers.create(
+        logger.debug(f"Creating container {container_name}...")
+        container = await self.batch_state.docker_client.create_container(
             config, name=container_name
         )
+        logger.debug(f"Starting container {container_name}...")
         await container.start()
         container_id: ContainerID = (await container.show())["Id"]
+        logger.debug(f"Container started with ID: {container_id}")
 
         # Check if container exited immediately after starting
         container_info = await container.show()
+        logger.debug(
+            f"Container info after start: State={container_info.get('State')}, "
+            f"Config={container_info.get('Config')}, "
+            f"NetworkSettings={container_info.get('NetworkSettings')}"
+        )
+
         if not container_info["State"]["Running"]:
             exit_code = container_info["State"].get("ExitCode", "unknown")
+            logger.debug(f"Container Info {container_info}")
+            error_msg = container_info["State"].get("Error", "")
+            started_at = container_info["State"].get("StartedAt", "")
+            finished_at = container_info["State"].get("FinishedAt", "")
+
+            logger.debug(
+                f"Container {container_name} exited immediately. "
+                f"Full container_info: {container_info}"
+            )
+
             # Get container logs to help diagnose the issue
             logs = await container.log(stdout=True, stderr=True)
             log_text = "".join(logs) if logs else "(no logs)"
+
+            logger.debug(
+                f"Container {container_name} details - "
+                f"exit_code={exit_code}, error={error_msg}, "
+                f"started_at={started_at}, finished_at={finished_at}, "
+                f"logs={log_text}"
+            )
+
             # Clean up the failed container
             try:
                 await container.delete()
-            except Exception:
-                pass  # Best effort cleanup
+                logger.debug(f"Cleaned up failed container {container_name}")
+            except Exception as cleanup_error:
+                logger.debug(f"Failed to clean up container {container_name}: {cleanup_error}")
+
             raise RuntimeError(
                 f"Container {container_name} exited immediately after starting "
                 f"with exit code {exit_code}. Logs:\n{log_text}"
@@ -324,6 +356,7 @@ class TaskSandboxContext:
         async with self._lock:
             self._containers[container_id] = ContainerInfo(container=container, temp_image=None)
 
+        logger.debug(f"Successfully created and tracked container {container_name}")
         return container_id
 
     async def _clone_container(
@@ -340,7 +373,7 @@ class TaskSandboxContext:
         Returns:
             Cloned container ID
         """
-        source_container = await self.batch_state.docker_client.containers.get(source_id)
+        source_container = await self.batch_state.docker_client.get_container(source_id)
 
         # Generate unique names
         clone_id = uuid.uuid4().hex[:8]
@@ -387,7 +420,7 @@ class TaskSandboxContext:
                     }
 
             # Create and start cloned container
-            cloned_container = await self.batch_state.docker_client.containers.create(
+            cloned_container = await self.batch_state.docker_client.create_container(
                 config=config, name=clone_name
             )
             await cloned_container.start()
@@ -412,7 +445,7 @@ class TaskSandboxContext:
                     pass  # Best effort
 
             try:
-                await self.batch_state.docker_client.images.delete(temp_image_full, force=True)
+                await self.batch_state.docker_client.delete_image(temp_image_full, force=True)
             except Exception:
                 pass  # Best effort
 
@@ -503,7 +536,7 @@ class TaskSandboxContext:
         # Remove temporary image if exists
         if info.temp_image:
             try:
-                await self.batch_state.docker_client.images.delete(info.temp_image, force=True)
+                await self.batch_state.docker_client.delete_image(info.temp_image, force=True)
             except Exception:
                 pass  # Best effort cleanup
 
@@ -514,7 +547,7 @@ class TaskSandboxContext:
             network_id: Network ID to clean up
         """
         try:
-            network = await self.batch_state.docker_client.networks.get(network_id)
+            network = await self.batch_state.docker_client.get_network(network_id)
             await network.delete()
         except Exception:
             pass  # Best effort cleanup

--- a/src/prompt_siren/sandbox_managers/docker/errors.py
+++ b/src/prompt_siren/sandbox_managers/docker/errors.py
@@ -1,0 +1,16 @@
+"""Common Docker client exceptions."""
+
+from __future__ import annotations
+
+
+class DockerClientError(Exception):
+    """Error executing Docker client command.
+
+    This exception is raised by any Docker client implementation (LocalDockerClient,
+    DesDockerClient, etc.) when a Docker operation fails.
+    """
+
+    def __init__(self, message: str, stdout: str = "", stderr: str = ""):
+        self.stdout = stdout
+        self.stderr = stderr
+        super().__init__(f"{message}\nstdout: {stdout}\nstderr: {stderr}")

--- a/src/prompt_siren/sandbox_managers/docker/exec_utils.py
+++ b/src/prompt_siren/sandbox_managers/docker/exec_utils.py
@@ -7,22 +7,14 @@ import shlex
 from pathlib import Path
 
 import anyio
-from aiohttp import ClientTimeout
 
-try:
-    import aiodocker
-except ImportError as e:
-    raise ImportError(
-        "Docker sandbox manager requires the 'docker' optional dependency. "
-        "Install with: pip install 'prompt-siren[docker]'"
-    ) from e
-
-from ..abstract import ExecOutput, ExecTimeoutError, StderrChunk, StdoutChunk
+from ..abstract import ExecOutput, ExecTimeoutError
 from ..sandbox_state import ContainerID
+from .abstract_client import AbstractDockerClient
 
 
 async def exec_in_container(
-    docker: aiodocker.Docker,
+    docker: AbstractDockerClient,
     container_id: ContainerID,
     cmd: str | list[str],
     stdin: str | bytes | None = None,
@@ -36,7 +28,7 @@ async def exec_in_container(
     """Execute a command in a Docker container.
 
     Args:
-        docker: Docker client
+        docker: Abstract Docker client
         container_id: Container ID to execute command in
         cmd: Command to execute (string or list of arguments)
         stdin: Optional stdin data to pass to the command
@@ -54,7 +46,7 @@ async def exec_in_container(
         ExecTimeoutError: If command execution exceeds timeout
     """
     # Get container
-    container = await docker.containers.get(container_id)
+    container = await docker.get_container(container_id)
     _shell_path = str(shell_path) if shell_path is not None else "/bin/bash"
 
     # Normalize command to bash -c format
@@ -68,49 +60,15 @@ async def exec_in_container(
     try:
         # Use anyio for timeout (Python 3.10 compatible)
         with anyio.fail_after(timeout_value):
-            # Create exec instance
-            exec_instance = await container.exec(
+            # Execute command in container
+            return await container.exec(
                 cmd=bash_cmd,
-                stdout=True,
-                stderr=True,
-                stdin=stdin is not None,
+                stdin=stdin,
                 user=user or "",
                 environment=env,
                 workdir=cwd,
+                timeout=timeout_value,
             )
-
-            # Start execution
-            stream = exec_instance.start(detach=False, timeout=ClientTimeout(total=timeout_value))
-
-            # Write stdin if provided
-            if stdin is not None:
-                if isinstance(stdin, str):
-                    stdin = stdin.encode()
-                await stream.write_in(stdin)
-                # Signal EOF on stdin without closing stdout/stderr
-                # Access transport directly like write_in() does
-                assert stream._resp is not None
-                assert stream._resp.connection is not None
-                transport = stream._resp.connection.transport
-                if transport and transport.can_write_eof():
-                    transport.write_eof()
-
-            # Read output
-            outputs = []
-            while True:
-                msg = await stream.read_out()
-                if msg is None:
-                    break
-                decoded = msg.data.decode("utf-8", errors="replace")
-                if msg.stream == 1:  # stdout
-                    outputs.append(StdoutChunk(content=decoded))
-                elif msg.stream == 2:  # stderr
-                    outputs.append(StderrChunk(content=decoded))
-
-            # Get exit code
-            exit_code = (await exec_instance.inspect())["ExitCode"]
-
-            return ExecOutput(outputs=outputs, exit_code=exit_code)
 
     except TimeoutError as e:
         raise ExecTimeoutError(container_id, cmd, timeout_value) from e

--- a/src/prompt_siren/sandbox_managers/docker/image_cache.py
+++ b/src/prompt_siren/sandbox_managers/docker/image_cache.py
@@ -4,21 +4,11 @@
 from __future__ import annotations
 
 import hashlib
-import io
-import tarfile
+import logging
 import tempfile
 from pathlib import Path
 
 from typing_extensions import assert_never
-
-try:
-    import aiodocker
-    from aiodocker import DockerError
-except ImportError as e:
-    raise ImportError(
-        "Docker sandbox manager requires the 'docker' optional dependency. "
-        "Install with: pip install 'prompt-siren[docker]'"
-    ) from e
 
 from ..image_spec import (
     BuildImageSpec,
@@ -28,6 +18,10 @@ from ..image_spec import (
     PullImageSpec,
 )
 from ..sandbox_task_setup import ContainerSetup
+from .abstract_client import AbstractDockerClient
+from .errors import DockerClientError
+
+logger = logging.getLogger(__name__)
 
 
 class ImageBuildError(Exception):
@@ -46,11 +40,11 @@ class ImageCache:
     concurrent Docker build race conditions.
     """
 
-    def __init__(self, docker: aiodocker.Docker, batch_id: str):
+    def __init__(self, docker: AbstractDockerClient, batch_id: str):
         """Initialize image cache.
 
         Args:
-            docker: Docker client for all operations
+            docker: Abstract Docker client for all operations
             batch_id: Unique identifier for this batch
         """
         self._docker = docker
@@ -68,13 +62,22 @@ class ImageCache:
         Args:
             container_setups: All container setups from all tasks in the batch
         """
+        logger.debug(
+            f"[ImageCache] ensure_all_base_images called with {len(container_setups)} container setups"
+        )
         # Collect unique image specs using cache key
         seen_specs: set[str] = set()
         for setup in container_setups:
             cache_key = self._get_cache_key(setup.spec.image_spec)
+            logger.debug(
+                f"[ImageCache] Processing setup '{setup.name}' with cache_key: {cache_key}"
+            )
             if cache_key not in seen_specs:
                 seen_specs.add(cache_key)
+                logger.debug(f"[ImageCache] Preparing base image for cache_key: {cache_key}")
                 await self._prepare_base_image(setup.spec.image_spec)
+            else:
+                logger.debug(f"[ImageCache] Skipping duplicate cache_key: {cache_key}")
 
     async def get_image_for_container(
         self,
@@ -115,23 +118,37 @@ class ImageCache:
             Image tag
         """
         cache_key = self._get_cache_key(spec)
+        logger.debug(f"[ImageCache] _prepare_base_image called for cache_key: {cache_key}")
 
         # Check cache first
         if cache_key in self._base_image_cache:
+            logger.debug(f"[ImageCache] Found cached image for cache_key: {cache_key}")
             return self._base_image_cache[cache_key]
+
+        logger.debug(
+            f"[ImageCache] No cached image found, preparing new image for spec type: {type(spec).__name__}"
+        )
+
+        tag: ImageTag = ""
 
         # Prepare image based on type
         match spec:
             case PullImageSpec():
+                logger.debug(f"[ImageCache] Pulling image: {spec.tag}")
                 tag = await self._pull_image(spec)
             case BuildImageSpec():
+                logger.debug(
+                    f"[ImageCache] Building image from spec: tag={spec.tag}, context={spec.context_path}, dockerfile={spec.dockerfile_path}"
+                )
                 tag = await self._build_image(spec)
             case MultiStageBuildImageSpec():
+                logger.debug(f"[ImageCache] Building multi-stage image: {spec.final_tag}")
                 tag = await self._build_multi_stage_image(spec)
             case _:
                 assert_never(spec)
 
         # Cache result
+        logger.debug(f"[ImageCache] Caching result for cache_key: {cache_key}, tag: {tag}")
         self._base_image_cache[cache_key] = tag
         return tag
 
@@ -209,12 +226,18 @@ class ImageCache:
         Returns:
             Image tag
         """
+        logger.debug(f"[ImageCache] _pull_image: Checking if image exists locally: {spec.tag}")
         try:
             # Check if image exists locally
-            await self._docker.images.inspect(spec.tag)
-        except DockerError:
+            await self._docker.inspect_image(spec.tag)
+            logger.debug(f"[ImageCache] _pull_image: Image {spec.tag} already exists locally")
+        except DockerClientError as e:
             # Image doesn't exist, pull it
-            await self._docker.images.pull(from_image=spec.tag)
+            logger.debug(
+                f"[ImageCache] _pull_image: Image {spec.tag} not found locally (error: {e}), pulling..."
+            )
+            await self._docker.pull_image(spec.tag)
+            logger.debug(f"[ImageCache] _pull_image: Successfully pulled image {spec.tag}")
         return spec.tag
 
     async def _build_image(self, spec: BuildImageSpec) -> ImageTag:
@@ -226,19 +249,33 @@ class ImageCache:
         Returns:
             Image tag
         """
+        logger.debug(f"[ImageCache] _build_image: Checking if image exists: {spec.tag}")
+        logger.debug(f"[ImageCache] _build_image: Build context path: {spec.context_path}")
+        logger.debug(f"[ImageCache] _build_image: Dockerfile path: {spec.dockerfile_path}")
+        logger.debug(f"[ImageCache] _build_image: Build args: {spec.build_args}")
+
         # Check if image exists
         try:
-            await self._docker.images.inspect(spec.tag)
+            logger.debug(f"[ImageCache] _build_image: Attempting to inspect image {spec.tag}")
+            await self._docker.inspect_image(spec.tag)
+            logger.debug(
+                f"[ImageCache] _build_image: Image {spec.tag} already exists, skipping build"
+            )
             return spec.tag
-        except DockerError:
-            pass  # Image doesn't exist, build it
+        except DockerClientError as e:
+            logger.debug(
+                f"[ImageCache] _build_image: Image {spec.tag} not found (error: {e}), proceeding with build"
+            )
+            # Image doesn't exist, build it
 
+        logger.debug(f"[ImageCache] _build_image: Starting build for image {spec.tag}")
         await self._build_from_context(
             context_path=spec.context_path,
             tag=spec.tag,
             dockerfile_path=spec.dockerfile_path,
             build_args=spec.build_args,
         )
+        logger.debug(f"[ImageCache] _build_image: Successfully built image {spec.tag}")
         return spec.tag
 
     async def _build_multi_stage_image(self, spec: MultiStageBuildImageSpec) -> ImageTag:
@@ -253,9 +290,9 @@ class ImageCache:
         for stage in spec.stages:
             # Check if stage image exists
             try:
-                await self._docker.images.inspect(stage.tag)
+                await self._docker.inspect_image(stage.tag)
                 continue  # Stage already built
-            except DockerError:
+            except DockerClientError:
                 pass  # Need to build this stage
 
             # Prepare build args
@@ -284,6 +321,9 @@ class ImageCache:
     ) -> None:
         """Build a Docker image from a build context.
 
+        The tar archive creation and file transfer is handled by the
+        Docker client implementation (local or DES).
+
         Args:
             context_path: Path to the build context directory
             tag: Tag for the built image
@@ -293,29 +333,34 @@ class ImageCache:
         Raises:
             ImageBuildError: If build fails
         """
-        # Create tar archive of build context
-        tar_stream = io.BytesIO()
-        with tarfile.open(fileobj=tar_stream, mode="w") as tar:
-            tar.add(context_path, arcname=".")
-        tar_stream.seek(0)
+        logger.debug(
+            f"[ImageCache] _build_from_context: Building image {tag} from context {context_path}"
+        )
+        logger.debug(f"[ImageCache] _build_from_context: Dockerfile path: {dockerfile_path}")
+        logger.debug(f"[ImageCache] _build_from_context: Build args: {build_args}")
 
         errors = []
 
-        # Stream build output
-        async for log_line in self._docker.images.build(
-            fileobj=tar_stream,
+        # Stream build output from client
+        async for log_line in self._docker.build_image(
+            context_path=context_path,
             tag=tag,
-            encoding="application/x-tar",
-            stream=True,
-            path_dockerfile=dockerfile_path or "Dockerfile",
+            dockerfile_path=dockerfile_path,
             buildargs=build_args,
         ):
+            logger.debug(f"[ImageCache] _build_from_context: Build log: {log_line}")
             if "error" in log_line:
                 error = log_line["error"]
+                logger.error(f"[ImageCache] _build_from_context: Build error: {error}")
                 errors.append(error)
 
         if errors:
+            logger.error(
+                f"[ImageCache] _build_from_context: Build failed with {len(errors)} errors"
+            )
             raise ImageBuildError(tag, errors)
+
+        logger.debug(f"[ImageCache] _build_from_context: Build completed successfully for {tag}")
 
     @staticmethod
     def _get_cache_key(spec: ImageSpec) -> str:

--- a/src/prompt_siren/sandbox_managers/docker/plugins/__init__.py
+++ b/src/prompt_siren/sandbox_managers/docker/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Docker client plugins."""

--- a/src/prompt_siren/sandbox_managers/docker/plugins/local_client.py
+++ b/src/prompt_siren/sandbox_managers/docker/plugins/local_client.py
@@ -1,0 +1,290 @@
+"""Local Docker client implementation using aiodocker."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from collections.abc import AsyncIterator
+from typing import Any
+
+try:
+    import aiodocker
+    from aiodocker.containers import DockerContainer
+    from aiodocker.exceptions import DockerError
+    from aiodocker.networks import DockerNetwork
+except ImportError as e:
+    raise ImportError(
+        "The local Docker client requires the 'docker' optional dependency. "
+        "Install with: pip install 'prompt-siren[docker]'"
+    ) from e
+
+from aiohttp import ClientTimeout
+
+from ...abstract import ExecOutput, StderrChunk, StdoutChunk
+from ..abstract_client import AbstractContainer, AbstractDockerClient, AbstractNetwork
+from ..errors import DockerClientError
+
+
+class LocalContainer(AbstractContainer):
+    """Local implementation of container using aiodocker."""
+
+    def __init__(self, container: DockerContainer):
+        self._container = container
+
+    async def start(self) -> None:
+        """Start the container."""
+        try:
+            await self._container.start()
+        except DockerError as e:
+            raise DockerClientError(f"Failed to start container: {e.message}") from e
+
+    async def stop(self) -> None:
+        """Stop the container."""
+        try:
+            await self._container.stop()
+        except DockerError as e:
+            raise DockerClientError(f"Failed to stop container: {e.message}") from e
+
+    async def delete(self) -> None:
+        """Delete the container."""
+        try:
+            await self._container.delete()
+        except DockerError as e:
+            raise DockerClientError(f"Failed to delete container: {e.message}") from e
+
+    async def show(self) -> dict[str, Any]:
+        """Get container details."""
+        try:
+            return await self._container.show()
+        except DockerError as e:
+            raise DockerClientError(f"Failed to get container details: {e.message}") from e
+
+    async def exec(
+        self,
+        cmd: list[str],
+        stdin: str | bytes | None,
+        user: str,
+        environment: dict[str, str] | None,
+        workdir: str | None,
+        timeout: int,
+    ) -> ExecOutput:
+        """Execute a command in the container with streaming I/O.
+
+        Args:
+            cmd: Command to execute (already in bash -c format)
+            stdin: Optional stdin data to pass to the command
+            user: User to run as
+            environment: Environment variables
+            workdir: Working directory
+            timeout: Timeout in seconds
+
+        Returns:
+            ExecOutput containing stdout/stderr chunks and exit code
+        """
+        try:
+            # Create exec instance
+            exec_instance = await self._container.exec(
+                cmd=cmd,
+                stdout=True,
+                stderr=True,
+                stdin=stdin is not None,
+                user=user,
+                environment=environment,
+                workdir=workdir,
+            )
+
+            # Start execution
+            stream = exec_instance.start(detach=False, timeout=ClientTimeout(total=timeout))
+
+            # Write stdin if provided
+            if stdin is not None:
+                if isinstance(stdin, str):
+                    stdin_bytes = stdin.encode()
+                else:
+                    stdin_bytes = stdin
+                await stream.write_in(stdin_bytes)
+                # Signal EOF on stdin without closing stdout/stderr
+                # Access transport directly like aiodocker's write_in() does
+                if stream._resp is not None and stream._resp.connection is not None:
+                    transport = stream._resp.connection.transport
+                    if transport and transport.can_write_eof():
+                        transport.write_eof()
+
+            # Read output
+            outputs = []
+            while True:
+                msg = await stream.read_out()
+                if msg is None:
+                    break
+                decoded = msg.data.decode("utf-8", errors="replace")
+                if msg.stream == 1:  # stdout
+                    outputs.append(StdoutChunk(content=decoded))
+                elif msg.stream == 2:  # stderr
+                    outputs.append(StderrChunk(content=decoded))
+
+            # Get exit code
+            exit_code = (await exec_instance.inspect())["ExitCode"]
+
+            return ExecOutput(outputs=outputs, exit_code=exit_code)
+        except DockerError as e:
+            raise DockerClientError(f"Failed to execute command in container: {e.message}") from e
+
+    async def log(self, stdout: bool, stderr: bool) -> list[str]:
+        """Get container logs."""
+        try:
+            return await self._container.log(stdout=stdout, stderr=stderr)
+        except DockerError as e:
+            raise DockerClientError(f"Failed to get container logs: {e.message}") from e
+
+    async def commit(self, repository: str, tag: str) -> None:
+        """Commit container to an image."""
+        try:
+            await self._container.commit(repository=repository, tag=tag)
+        except DockerError as e:
+            raise DockerClientError(
+                f"Failed to commit container to {repository}:{tag}: {e.message}"
+            ) from e
+
+
+class LocalNetwork(AbstractNetwork):
+    """Local implementation of network using aiodocker."""
+
+    def __init__(self, network: DockerNetwork):
+        self._network = network
+
+    async def show(self) -> dict[str, Any]:
+        """Get network details."""
+        try:
+            return await self._network.show()
+        except DockerError as e:
+            raise DockerClientError(f"Failed to get network details: {e.message}") from e
+
+    async def delete(self) -> None:
+        """Delete the network."""
+        try:
+            await self._network.delete()
+        except DockerError as e:
+            raise DockerClientError(f"Failed to delete network: {e.message}") from e
+
+
+class LocalDockerClient(AbstractDockerClient):
+    """Local Docker client implementation using aiodocker.
+
+    This implementation wraps aiodocker to provide Docker operations on the local machine.
+    """
+
+    def __init__(self):
+        """Initialize local Docker client."""
+        self._docker = aiodocker.Docker()
+
+    async def close(self) -> None:
+        """Close the Docker client."""
+        await self._docker.close()
+
+    # Image operations
+
+    async def inspect_image(self, tag: str) -> dict[str, Any]:
+        """Inspect an image."""
+        try:
+            return await self._docker.images.inspect(tag)
+        except DockerError as e:
+            raise DockerClientError(f"Failed to inspect image {tag}: {e.message}") from e
+
+    async def pull_image(self, tag: str) -> None:
+        """Pull an image from registry."""
+        try:
+            await self._docker.images.pull(from_image=tag)
+        except DockerError as e:
+            raise DockerClientError(f"Failed to pull image {tag}: {e.message}") from e
+
+    async def build_image(
+        self,
+        context_path: str,
+        tag: str,
+        dockerfile_path: str | None = None,
+        buildargs: dict[str, str] | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Build an image from a build context directory.
+
+        Creates a tar archive of the context and sends it to Docker.
+        """
+        # Create tar archive of build context with normalized ownership
+        tar_stream = io.BytesIO()
+
+        def reset_ownership(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo:
+            """Reset ownership to root to avoid user namespace issues."""
+            tarinfo.uid = 0
+            tarinfo.gid = 0
+            tarinfo.uname = "root"
+            tarinfo.gname = "root"
+            return tarinfo
+
+        with tarfile.open(fileobj=tar_stream, mode="w") as tar:
+            tar.add(context_path, arcname=".", filter=reset_ownership)
+        tar_stream.seek(0)
+
+        # Build image from tar archive
+        try:
+            async for log_line in self._docker.images.build(
+                fileobj=tar_stream,
+                tag=tag,
+                encoding="application/x-tar",
+                stream=True,
+                path_dockerfile=dockerfile_path or "Dockerfile",
+                buildargs=buildargs,
+            ):
+                yield log_line
+        except DockerError as e:
+            raise DockerClientError(f"Failed to build image {tag}: {e.message}") from e
+
+    async def delete_image(self, tag: str, force: bool = False) -> None:
+        """Delete an image."""
+        try:
+            await self._docker.images.delete(tag, force=force)
+        except DockerError as e:
+            raise DockerClientError(f"Failed to delete image {tag}: {e.message}") from e
+
+    # Container operations
+
+    async def create_container(self, config: dict[str, Any], name: str) -> AbstractContainer:
+        """Create a container."""
+        try:
+            container = await self._docker.containers.create(config, name=name)
+            return LocalContainer(container)
+        except DockerError as e:
+            raise DockerClientError(f"Failed to create container {name}: {e.message}") from e
+
+    async def get_container(self, container_id: str) -> AbstractContainer:
+        """Get a container by ID."""
+        try:
+            container = await self._docker.containers.get(container_id)
+            return LocalContainer(container)
+        except DockerError as e:
+            raise DockerClientError(f"Failed to get container {container_id}: {e.message}") from e
+
+    # Network operations
+
+    async def create_network(self, config: dict[str, Any]) -> AbstractNetwork:
+        """Create a network."""
+        try:
+            network = await self._docker.networks.create(config=config)
+            return LocalNetwork(network)
+        except DockerError as e:
+            raise DockerClientError(f"Failed to create network: {e.message}") from e
+
+    async def get_network(self, network_id: str) -> AbstractNetwork:
+        """Get a network by ID."""
+        try:
+            network = await self._docker.networks.get(network_id)
+            return LocalNetwork(network)
+        except DockerError as e:
+            raise DockerClientError(f"Failed to get network {network_id}: {e.message}") from e
+
+
+def create_local_docker_client() -> LocalDockerClient:
+    """Factory function to create a LocalDockerClient instance.
+
+    Returns:
+        LocalDockerClient instance configured for local Docker access
+    """
+    return LocalDockerClient()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,10 +1,17 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-"""Pytest fixtures for Docker integration tests."""
+"""Pytest fixtures for Docker integration tests.
 
-from collections.abc import AsyncIterator
+External tests use local Docker client only.
+For DES support, see internal/tests/integration/conftest.py
+"""
+
+from collections.abc import AsyncIterator, Callable
 
 import pytest
-from aiodocker import Docker
+from prompt_siren.sandbox_managers.docker.abstract_client import AbstractDockerClient
+from prompt_siren.sandbox_managers.docker.errors import DockerClientError
+from prompt_siren.sandbox_managers.docker.manager import DockerSandboxConfig
+from prompt_siren.sandbox_managers.docker.plugins.local_client import LocalDockerClient
 
 
 @pytest.fixture(scope="module")
@@ -14,30 +21,114 @@ def anyio_backend() -> str:
 
 
 @pytest.fixture(scope="module")
-async def docker_client() -> AsyncIterator[Docker]:
-    """Provide a shared Docker client for all integration tests in the module.
+def docker_client_type() -> str:
+    """Docker client type for external tests.
 
-    Module-scoped to avoid creating a new connection for each test.
+    External tests always use local Docker client.
+    For DES support, run tests from internal directory.
     """
-    docker = Docker()
-    try:
-        yield docker
-    finally:
-        await docker.close()
+    return "local"
 
 
 @pytest.fixture(scope="module")
-async def test_image(docker_client: Docker):
+def skip_if_des_unavailable(docker_client_type: str):
+    """Skip test if DES client is requested but unavailable.
+
+    This is a no-op for external tests (always local).
+    Kept for compatibility with shared test code.
+    """
+
+
+@pytest.fixture(scope="module")
+def create_manager_config() -> Callable[[str, bool, str | list[str] | None], DockerSandboxConfig]:
+    """Factory fixture for creating DockerSandboxConfig.
+
+    External version only supports local Docker.
+    Internal version (see internal/tests/integration/conftest.py) adds DES support.
+
+    Returns:
+        A callable that creates DockerSandboxConfig instances
+    """
+
+    def _create_config(
+        docker_client_type: str,
+        network_enabled: bool = False,
+        test_images: str | list[str] | None = None,
+    ) -> DockerSandboxConfig:
+        """Create DockerSandboxConfig for external tests (local only).
+
+        Args:
+            docker_client_type: Client type ('local' for external)
+            network_enabled: Whether to enable network access
+            test_images: Test image(s) - used by internal DES tests
+
+        Returns:
+            DockerSandboxConfig configured for local Docker
+
+        Raises:
+            ValueError: If docker_client_type is not 'local' (in external)
+        """
+        if docker_client_type != "local":
+            raise ValueError(
+                f"External tests only support 'local' client type. "
+                f"For DES support, run tests from internal directory. "
+                f"Got: {docker_client_type}"
+            )
+
+        return DockerSandboxConfig(network_enabled=network_enabled, docker_client="local")
+
+    return _create_config
+
+
+@pytest.fixture(scope="module")
+async def docker_client() -> AsyncIterator[AbstractDockerClient]:
+    """Provide a shared Docker client for all integration tests in the module.
+
+    Module-scoped to avoid creating a new connection for each test.
+    External tests always use local Docker client plugin.
+    """
+    client = LocalDockerClient()
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+@pytest.fixture(scope="module")
+async def test_image(docker_client: AbstractDockerClient):
     """Pull the test image once for all tests in the module.
 
     Uses debian:bookworm-slim for small size with bash support.
     Module-scoped to avoid repeated image checks.
     """
-    image = "debian:bookworm-slim"
+    image = "vmvm-registry.fbinfra.net/debian:bookworm-slim"
+
     # Check if image exists locally before attempting pull (avoids rate limits)
     try:
-        await docker_client.images.inspect(image)
-    except Exception:
+        await docker_client.inspect_image(image)
+    except DockerClientError:
         # Image doesn't exist, pull it
-        await docker_client.images.pull(from_image=image)
+        await docker_client.pull_image(image)
     return image
+
+
+@pytest.fixture(scope="module")
+async def multistage_test_images(docker_client: AbstractDockerClient):
+    """Pull the images needed for multi-stage build tests.
+
+    Returns a list of images needed for multi-stage builds.
+    Module-scoped to avoid repeated image checks.
+    """
+    images = [
+        "vmvm-registry.fbinfra.net/debian:bookworm-slim",
+        "vmvm-registry.fbinfra.net/alpine:3.19",
+    ]
+
+    for image in images:
+        # Check if image exists locally before attempting pull (avoids rate limits)
+        try:
+            await docker_client.inspect_image(image)
+        except DockerClientError:
+            # Image doesn't exist, pull it
+            await docker_client.pull_image(image)
+    return images

--- a/tests/integration/test_bash_env.py
+++ b/tests/integration/test_bash_env.py
@@ -94,7 +94,7 @@ class TestSingleContainerTask:
                 # Verify container is actually running
                 assert bash_env._sandbox_manager._batch_state is not None
                 docker = bash_env._sandbox_manager._batch_state.docker_client
-                container = await docker.containers.get(env_state.agent_container_id)
+                container = await docker.get_container(env_state.agent_container_id)
                 container_info = await container.show()
                 assert container_info["State"]["Running"] is True
 
@@ -133,8 +133,8 @@ class TestSingleContainerTask:
                 # Verify both containers are running
                 assert bash_env._sandbox_manager._batch_state is not None
                 docker = bash_env._sandbox_manager._batch_state.docker_client
-                original_container = await docker.containers.get(original_container_id)
-                cloned_container = await docker.containers.get(cloned_env_state.agent_container_id)
+                original_container = await docker.get_container(original_container_id)
+                cloned_container = await docker.get_container(cloned_env_state.agent_container_id)
 
                 original_info = await original_container.show()
                 cloned_info = await cloned_container.show()
@@ -197,8 +197,8 @@ class TestMultiContainerTaskCouple:
                 assert bash_env._sandbox_manager._batch_state is not None
                 docker = bash_env._sandbox_manager._batch_state.docker_client
 
-                benign_container = await docker.containers.get(env_state.agent_container_id)
-                attack_container = await docker.containers.get(attack_container_id)
+                benign_container = await docker.get_container(env_state.agent_container_id)
+                attack_container = await docker.get_container(attack_container_id)
 
                 benign_info = await benign_container.show()
                 attack_info = await attack_container.show()
@@ -285,8 +285,8 @@ class TestMultiContainerTaskCouple:
                 assert bash_env._sandbox_manager._batch_state is not None
                 docker = bash_env._sandbox_manager._batch_state.docker_client
 
-                cloned_benign = await docker.containers.get(cloned_env_state.agent_container_id)
-                cloned_attack = await docker.containers.get(cloned_attack_id)
+                cloned_benign = await docker.get_container(cloned_env_state.agent_container_id)
+                cloned_attack = await docker.get_container(cloned_attack_id)
 
                 cloned_benign_info = await cloned_benign.show()
                 cloned_attack_info = await cloned_attack.show()
@@ -356,7 +356,7 @@ class TestMultiContainerTaskCouple:
                 assert bash_env._sandbox_manager._batch_state is not None
                 docker = bash_env._sandbox_manager._batch_state.docker_client
 
-                agent_container = await docker.containers.get(env_state.agent_container_id)
+                agent_container = await docker.get_container(env_state.agent_container_id)
                 container_info = await agent_container.show()
                 image_name = container_info["Config"]["Image"]
 
@@ -419,14 +419,14 @@ class TestMultiContainerTaskCouple:
                 assert bash_env._sandbox_manager._batch_state is not None
                 docker = bash_env._sandbox_manager._batch_state.docker_client
 
-                agent_container = await docker.containers.get(env_state.agent_container_id)
-                attack_container = await docker.containers.get(
+                agent_container = await docker.get_container(env_state.agent_container_id)
+                attack_container = await docker.get_container(
                     env_state.sandbox_state.service_containers["attack_server"]
                 )
-                db_container = await docker.containers.get(
+                db_container = await docker.get_container(
                     env_state.sandbox_state.service_containers["database"]
                 )
-                cache_container = await docker.containers.get(
+                cache_container = await docker.get_container(
                     env_state.sandbox_state.service_containers["cache"]
                 )
 
@@ -633,7 +633,7 @@ class TestMultiContainerTaskCouple:
                 assert bash_env._sandbox_manager._batch_state is not None
                 docker = bash_env._sandbox_manager._batch_state.docker_client
                 service_id = env_state.sandbox_state.service_containers["http_server"]
-                service_container = await docker.containers.get(service_id)
+                service_container = await docker.get_container(service_id)
                 service_info = await service_container.show()
 
                 # If container crashed, get logs to understand why

--- a/tests/integration/test_docker_manager_integration.py
+++ b/tests/integration/test_docker_manager_integration.py
@@ -11,14 +11,13 @@ Skip with: pytest -vx -m "not docker_integration"
 from __future__ import annotations
 
 import asyncio
-import os
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from uuid import uuid4
 
 import pytest
-from aiodocker import Docker
 from prompt_siren.sandbox_managers.abstract import AbstractSandboxManager
+from prompt_siren.sandbox_managers.docker.abstract_client import AbstractDockerClient
 from prompt_siren.sandbox_managers.docker.manager import (
     DockerSandboxConfig,
     DockerSandboxManager,
@@ -39,6 +38,9 @@ from prompt_siren.sandbox_managers.sandbox_task_setup import (
 
 pytestmark = pytest.mark.anyio
 
+# Path to test fixtures
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
 
 # ==================== Shared Fixtures for Container Reuse ====================
 
@@ -46,12 +48,17 @@ pytestmark = pytest.mark.anyio
 @pytest.fixture(scope="module")
 async def basic_sandbox_manager(
     test_image: str,
+    docker_client_type: str,
+    skip_if_des_unavailable,
+    create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
 ) -> AsyncIterator[tuple[AbstractSandboxManager, TaskSetup]]:
     """Create a sandbox manager with batch context for basic tests.
 
     Module-scoped to reuse across tests for performance.
     """
-    config = DockerSandboxConfig(network_enabled=False)
+    config = create_manager_config(
+        docker_client_type, network_enabled=False, test_images=test_image
+    )
     manager = DockerSandboxManager(config)
 
     container_spec = ContainerSpec(image_spec=PullImageSpec(tag=test_image))
@@ -219,15 +226,22 @@ class TestBasicContainerOperations:
 class TestMultiContainerNetworking:
     """Tests for multi-container setups with networking."""
 
-    async def test_multi_container_dns_resolution_and_communication(self, test_image: str):
+    async def test_multi_container_dns_resolution_and_communication(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
         """Test that containers on the same network can resolve each other by hostname."""
-        config = DockerSandboxConfig(network_enabled=True)
+        config = create_manager_config(
+            docker_client_type, network_enabled=True, test_images=test_image
+        )
         manager = DockerSandboxManager(config)
 
         # Use custom test image with netcat pre-installed
-        fixtures_dir = os.path.join(os.path.dirname(__file__), "fixtures")
         network_image_spec = BuildImageSpec(
-            context_path=fixtures_dir,
+            context_path=str(FIXTURES_DIR),
             dockerfile_path="Dockerfile.network",
             tag="prompt-siren-network-test:latest",
         )
@@ -287,9 +301,18 @@ class TestMultiContainerNetworking:
                 assert result.stdout is not None
                 assert "test-message" in result.stdout
 
-    async def test_network_disabled_creates_internal_network(self, test_image: str):
+    async def test_network_disabled_creates_internal_network(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        docker_client: AbstractDockerClient | None,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
         """Test that network_enabled=False creates internal-only network for multi-container."""
-        config = DockerSandboxConfig(network_enabled=False)
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
         manager = DockerSandboxManager(config)
 
         container_spec = ContainerSpec(
@@ -312,13 +335,12 @@ class TestMultiContainerNetworking:
                 assert sandbox_state.network_id is not None
 
                 # Verify network is internal by inspecting it
-                docker = Docker()
-                try:
-                    network = await docker.networks.get(sandbox_state.network_id)
+                # (Only for local docker - DES doesn't expose network inspect)
+                if docker_client_type == "local":
+                    assert docker_client is not None
+                    network = await docker_client.get_network(sandbox_state.network_id)
                     network_info = await network.show()
                     assert network_info["Internal"] is True
-                finally:
-                    await docker.close()
 
 
 # ==================== Container Cloning Tests ====================
@@ -328,9 +350,17 @@ class TestMultiContainerNetworking:
 class TestContainerCloning:
     """Tests for container cloning functionality."""
 
-    async def test_clone_single_container(self, test_image: str):
+    async def test_clone_single_container(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
         """Test cloning a single container creates snapshot."""
-        config = DockerSandboxConfig(network_enabled=False)
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
         manager = DockerSandboxManager(config)
 
         container_spec = ContainerSpec(image_spec=PullImageSpec(tag=test_image))
@@ -380,9 +410,18 @@ class TestContainerCloning:
                 assert "source content" in result.stdout
                 assert "modified" not in result.stdout
 
-    async def test_clone_container_with_custom_command(self, test_image: str):
+    async def test_clone_container_with_custom_command(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        docker_client: AbstractDockerClient | None,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
         """Test cloning a container with custom command preserves and runs the command."""
-        config = DockerSandboxConfig(network_enabled=False)
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
         manager = DockerSandboxManager(config)
 
         # Create container with custom command that keeps running
@@ -403,38 +442,42 @@ class TestContainerCloning:
             network_config=None,
         )
 
-        docker = Docker()
-        try:
-            async with manager.setup_batch([task_setup]):
-                async with manager.setup_task(task_setup) as source_state:
-                    source_id = source_state.agent_container_id
+        async with manager.setup_batch([task_setup]):
+            async with manager.setup_task(task_setup) as source_state:
+                source_id = source_state.agent_container_id
 
+                # Only inspect Docker API for local docker
+                if docker_client_type == "local":
+                    assert docker_client is not None
                     # Verify source container's command via Docker API
-                    source_container = await docker.containers.get(source_id)
+                    source_container = await docker_client.get_container(source_id)
                     source_info = await source_container.show()
                     source_cmd = source_info["Config"]["Cmd"]
                     assert source_cmd == custom_command
 
-                    # Verify command is actually running in source container
-                    # Use /proc filesystem which is available in all Linux containers
-                    await asyncio.sleep(0.5)  # Give process time to start
-                    cmdline_result = await manager.exec(
-                        source_id,
-                        ["sh", "-c", "cat /proc/*/cmdline | tr '\\0' '\\n'"],
-                    )
-                    assert cmdline_result.exit_code == 0
-                    assert cmdline_result.stdout is not None
-                    assert "custom-process-marker" in cmdline_result.stdout
+                # Verify command is actually running in source container
+                # Use /proc filesystem which is available in all Linux containers
+                await asyncio.sleep(0.5)  # Give process time to start
+                cmdline_result = await manager.exec(
+                    source_id,
+                    ["sh", "-c", "cat /proc/*/cmdline | tr '\\0' '\\n'"],
+                )
+                assert cmdline_result.exit_code == 0
+                assert cmdline_result.stdout is not None
+                assert "custom-process-marker" in cmdline_result.stdout
 
-                    # Clone the container
-                    cloned_state = await manager.clone_sandbox_state(source_state)
-                    cloned_id = cloned_state.agent_container_id
+                # Clone the container
+                cloned_state = await manager.clone_sandbox_state(source_state)
+                cloned_id = cloned_state.agent_container_id
 
-                    # Verify clone has different container ID
-                    assert cloned_id != source_id
+                # Verify clone has different container ID
+                assert cloned_id != source_id
 
+                # Only inspect Docker API for local docker
+                if docker_client_type == "local":
+                    assert docker_client is not None
                     # Verify cloned container's command via Docker API
-                    cloned_container = await docker.containers.get(cloned_id)
+                    cloned_container = await docker_client.get_container(cloned_id)
                     cloned_info = await cloned_container.show()
                     cloned_cmd = cloned_info["Config"]["Cmd"]
                     assert cloned_cmd == custom_command
@@ -443,20 +486,27 @@ class TestContainerCloning:
                     assert source_info["State"]["Running"] is True
                     assert cloned_info["State"]["Running"] is True
 
-                    # Verify command is actually running in cloned container
-                    cloned_cmdline_result = await manager.exec(
-                        cloned_id,
-                        ["sh", "-c", "cat /proc/*/cmdline | tr '\\0' '\\n'"],
-                    )
-                    assert cloned_cmdline_result.exit_code == 0
-                    assert cloned_cmdline_result.stdout is not None
-                    assert "custom-process-marker" in cloned_cmdline_result.stdout
-        finally:
-            await docker.close()
+                # Verify command is actually running in cloned container
+                cloned_cmdline_result = await manager.exec(
+                    cloned_id,
+                    ["sh", "-c", "cat /proc/*/cmdline | tr '\\0' '\\n'"],
+                )
+                assert cloned_cmdline_result.exit_code == 0
+                assert cloned_cmdline_result.stdout is not None
+                assert "custom-process-marker" in cloned_cmdline_result.stdout
 
-    async def test_clone_multi_container_with_network(self, test_image: str):
+    async def test_clone_multi_container_with_network(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        docker_client: AbstractDockerClient | None,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
         """Test cloning multi-container setup clones network too."""
-        config = DockerSandboxConfig(network_enabled=True)
+        config = create_manager_config(
+            docker_client_type, network_enabled=True, test_images=test_image
+        )
         manager = DockerSandboxManager(config)
 
         container_spec = ContainerSpec(
@@ -490,19 +540,26 @@ class TestContainerCloning:
                 assert cloned_state.network_id is not None
 
                 # Verify cloned containers can communicate on new network
-                # (Use Docker API to verify network attachment)
-                docker = Docker()
-                try:
-                    clone_agent = await docker.containers.get(cloned_state.agent_container_id)
+                # (Use Docker API to verify network attachment - only for local)
+                if docker_client_type == "local":
+                    assert docker_client is not None
+                    clone_agent = await docker_client.get_container(cloned_state.agent_container_id)
                     clone_info = await clone_agent.show()
                     networks = clone_info["NetworkSettings"]["Networks"]
                     assert len(networks) > 0
-                finally:
-                    await docker.close()
 
-    async def test_clone_cleanup_removes_temp_images(self, test_image: str):
+    async def test_clone_cleanup_removes_temp_images(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        docker_client: AbstractDockerClient | None,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
         """Test that cloning cleanup removes temporary images."""
-        config = DockerSandboxConfig(network_enabled=False)
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
         manager = DockerSandboxManager(config)
 
         container_spec = ContainerSpec(image_spec=PullImageSpec(tag=test_image))
@@ -514,24 +571,27 @@ class TestContainerCloning:
             network_config=None,
         )
 
-        docker = Docker()
-        try:
-            async with manager.setup_batch([task_setup]):
-                async with manager.setup_task(task_setup) as source_state:
-                    # Clone multiple times
-                    cloned_states = []
-                    for _ in range(3):
-                        cloned_state = await manager.clone_sandbox_state(source_state)
-                        cloned_states.append(cloned_state)
+        async with manager.setup_batch([task_setup]):
+            async with manager.setup_task(task_setup) as source_state:
+                # Clone multiple times
+                cloned_states = []
+                for _ in range(3):
+                    cloned_state = await manager.clone_sandbox_state(source_state)
+                    cloned_states.append(cloned_state)
 
+                # Only verify temp images for local docker
+                if docker_client_type == "local":
+                    assert docker_client is not None
                     # Verify temp images exist
-                    images = await docker.images.list()
+                    images = await docker_client.images.list()
                     image_tags = [tag for img in images for tag in img.get("RepoTags", [])]
                     temp_images_count = sum(1 for tag in image_tags if tag and "temp-clone-" in tag)
                     assert temp_images_count >= 3
 
-                # After task cleanup, temp images should be gone
-                images = await docker.images.list()
+            # After task cleanup, temp images should be gone (only check for local)
+            if docker_client_type == "local":
+                assert docker_client is not None
+                images = await docker_client.images.list()
                 image_tags = [tag for img in images for tag in img.get("RepoTags", [])]
 
                 # Filter for temp images from this specific execution
@@ -540,8 +600,6 @@ class TestContainerCloning:
                     # Verify this specific clone's temp image is gone
                     temp_image_pattern = f"temp-clone-{cloned_state.execution_id}"
                     assert not any(temp_image_pattern in (tag or "") for tag in image_tags)
-        finally:
-            await docker.close()
 
 
 # ==================== Concurrent Execution Tests ====================
@@ -551,9 +609,17 @@ class TestContainerCloning:
 class TestConcurrentExecution:
     """Tests for concurrent task execution."""
 
-    async def test_parallel_tasks_with_same_task_id(self, test_image: str):
+    async def test_parallel_tasks_with_same_task_id(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
         """Test that parallel tasks with same task_id are independent."""
-        config = DockerSandboxConfig(network_enabled=False)
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
         manager = DockerSandboxManager(config)
 
         container_spec = ContainerSpec(image_spec=PullImageSpec(tag=test_image))
@@ -593,9 +659,17 @@ class TestConcurrentExecution:
             assert len(container_ids) == 5
             assert len(set(container_ids)) == 5
 
-    async def test_concurrent_cloning(self, test_image: str):
+    async def test_concurrent_cloning(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
         """Test that concurrent cloning operations are safe."""
-        config = DockerSandboxConfig(network_enabled=False)
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
         manager = DockerSandboxManager(config)
 
         container_spec = ContainerSpec(image_spec=PullImageSpec(tag=test_image))
@@ -636,13 +710,22 @@ class TestConcurrentExecution:
 class TestImageBuilding:
     """Tests for building Docker images from Dockerfiles."""
 
-    async def test_build_image_from_dockerfile(self, test_image: str):
+    async def test_build_image_from_dockerfile(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        docker_client: AbstractDockerClient | None,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
         """Test building an image from a Dockerfile using BuildImageSpec."""
-        config = DockerSandboxConfig(network_enabled=False)
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
         manager = DockerSandboxManager(config)
 
         build_spec = BuildImageSpec(
-            context_path="tests/integration/fixtures",
+            context_path=str(FIXTURES_DIR),
             tag="prompt-siren-test-build:latest",
         )
 
@@ -655,44 +738,56 @@ class TestImageBuilding:
             network_config=None,
         )
 
-        docker = Docker()
-        try:
-            # Cleanup any existing test image
+        # Cleanup any existing test image (only for local)
+        if docker_client_type == "local":
+            assert docker_client is not None
             try:
-                await docker.images.delete("prompt-siren-test-build:latest", force=True)
+                await docker_client.images.delete("prompt-siren-test-build:latest", force=True)
             except Exception:
                 pass
 
-            async with manager.setup_batch([task_setup]):
-                # Verify image was built
-                images = await docker.images.list()
+        async with manager.setup_batch([task_setup]):
+            # Verify image was built (only for local)
+            if docker_client_type == "local":
+                assert docker_client is not None
+                images = await docker_client.images.list()
                 image_tags = [tag for img in images for tag in img.get("RepoTags", [])]
                 assert any("prompt-siren-test-build:latest" in (tag or "") for tag in image_tags)
 
-                # Create container and verify build marker
-                async with manager.setup_task(task_setup) as sandbox_state:
-                    result = await manager.exec(
-                        sandbox_state.agent_container_id,
-                        ["cat", "/test-marker.txt"],
-                    )
-                    assert result.exit_code == 0
-                    assert result.stdout is not None
-                    assert "Test build successful" in result.stdout
-        finally:
-            # Cleanup
+            # Create container and verify build marker
+            async with manager.setup_task(task_setup) as sandbox_state:
+                result = await manager.exec(
+                    sandbox_state.agent_container_id,
+                    ["cat", "/test-marker.txt"],
+                )
+                assert result.exit_code == 0
+                assert result.stdout is not None
+                assert "Test build successful" in result.stdout
+
+        # Cleanup (only for local)
+        if docker_client_type == "local":
+            assert docker_client is not None
             try:
-                await docker.images.delete("prompt-siren-test-build:latest", force=True)
+                await docker_client.images.delete("prompt-siren-test-build:latest", force=True)
             except Exception:
                 pass
-            await docker.close()
 
-    async def test_build_with_build_args(self):
+    async def test_build_with_build_args(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        docker_client: AbstractDockerClient | None,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
         """Test building an image with build_args and custom dockerfile_path."""
-        config = DockerSandboxConfig(network_enabled=False)
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
         manager = DockerSandboxManager(config)
 
         build_spec = BuildImageSpec(
-            context_path="tests/integration/fixtures",
+            context_path=str(FIXTURES_DIR),
             dockerfile_path="Dockerfile.dev",
             tag="prompt-siren-test-build-args:latest",
             build_args={"TEST_ARG": "custom_value"},
@@ -707,40 +802,50 @@ class TestImageBuilding:
             network_config=None,
         )
 
-        docker = Docker()
-        try:
-            # Cleanup any existing test image
+        # Cleanup any existing test image (only for local)
+        if docker_client_type == "local":
+            assert docker_client is not None
             try:
-                await docker.images.delete("prompt-siren-test-build-args:latest", force=True)
+                await docker_client.images.delete("prompt-siren-test-build-args:latest", force=True)
             except Exception:
                 pass
 
-            async with manager.setup_batch([task_setup]):
-                async with manager.setup_task(task_setup) as sandbox_state:
-                    # Verify build arg was used
-                    result = await manager.exec(
-                        sandbox_state.agent_container_id,
-                        ["cat", "/build-arg-test.txt"],
-                    )
-                    assert result.exit_code == 0
-                    assert result.stdout is not None
-                    assert "custom_value" in result.stdout
-        finally:
-            # Cleanup
+        async with manager.setup_batch([task_setup]):
+            async with manager.setup_task(task_setup) as sandbox_state:
+                # Verify build arg was used
+                result = await manager.exec(
+                    sandbox_state.agent_container_id,
+                    ["cat", "/build-arg-test.txt"],
+                )
+                assert result.exit_code == 0
+                assert result.stdout is not None
+                assert "custom_value" in result.stdout
+
+        # Cleanup (only for local)
+        if docker_client_type == "local":
+            assert docker_client is not None
             try:
-                await docker.images.delete("prompt-siren-test-build-args:latest", force=True)
+                await docker_client.images.delete("prompt-siren-test-build-args:latest", force=True)
             except Exception:
                 pass
-            await docker.close()
 
-    async def test_mixed_pull_and_build_specs(self, test_image: str):
+    async def test_mixed_pull_and_build_specs(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        docker_client: AbstractDockerClient | None,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
         """Test using both PullImageSpec and BuildImageSpec in the same batch."""
-        config = DockerSandboxConfig(network_enabled=False)
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
         manager = DockerSandboxManager(config)
 
         pull_spec = PullImageSpec(tag=test_image)
         build_spec = BuildImageSpec(
-            context_path="tests/integration/fixtures",
+            context_path=str(FIXTURES_DIR),
             tag="prompt-siren-test-mixed:latest",
         )
 
@@ -762,38 +867,39 @@ class TestImageBuilding:
             ),
         ]
 
-        docker = Docker()
-        try:
-            # Cleanup any existing test image
+        # Cleanup any existing test image (only for local)
+        if docker_client_type == "local":
+            assert docker_client is not None
             try:
-                await docker.images.delete("prompt-siren-test-mixed:latest", force=True)
+                await docker_client.images.delete("prompt-siren-test-mixed:latest", force=True)
             except Exception:
                 pass
 
-            async with manager.setup_batch(task_setups):
-                # Create containers from both images
-                async with manager.setup_task(task_setups[0]) as pulled_state:
-                    result1 = await manager.exec(
-                        pulled_state.agent_container_id,
-                        ["echo", "pulled"],
-                    )
-                    assert result1.exit_code == 0
+        async with manager.setup_batch(task_setups):
+            # Create containers from both images
+            async with manager.setup_task(task_setups[0]) as pulled_state:
+                result1 = await manager.exec(
+                    pulled_state.agent_container_id,
+                    ["echo", "pulled"],
+                )
+                assert result1.exit_code == 0
 
-                async with manager.setup_task(task_setups[1]) as built_state:
-                    result2 = await manager.exec(
-                        built_state.agent_container_id,
-                        ["cat", "/test-marker.txt"],
-                    )
-                    assert result2.exit_code == 0
-                    assert result2.stdout is not None
-                    assert "Test build successful" in result2.stdout
-        finally:
-            # Cleanup
+            async with manager.setup_task(task_setups[1]) as built_state:
+                result2 = await manager.exec(
+                    built_state.agent_container_id,
+                    ["cat", "/test-marker.txt"],
+                )
+                assert result2.exit_code == 0
+                assert result2.stdout is not None
+                assert "Test build successful" in result2.stdout
+
+        # Cleanup (only for local)
+        if docker_client_type == "local":
+            assert docker_client is not None
             try:
-                await docker.images.delete("prompt-siren-test-mixed:latest", force=True)
+                await docker_client.images.delete("prompt-siren-test-mixed:latest", force=True)
             except Exception:
                 pass
-            await docker.close()
 
 
 # ==================== Multi-Stage Build Tests ====================
@@ -803,9 +909,18 @@ class TestImageBuilding:
 class TestMultiStageBuild:
     """Tests for multi-stage Docker builds with caching."""
 
-    async def test_multi_stage_build_creates_all_stages(self):
+    async def test_multi_stage_build_creates_all_stages(
+        self,
+        multistage_test_images: list[str],
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        docker_client: AbstractDockerClient | None,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
         """Test that multi-stage build creates all three stages correctly."""
-        config = DockerSandboxConfig(network_enabled=False)
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=multistage_test_images
+        )
         manager = DockerSandboxManager(config)
 
         base_tag = "test-multistage-base:latest"
@@ -815,18 +930,18 @@ class TestMultiStageBuild:
         stages = [
             BuildStage(
                 tag=base_tag,
-                context_path="tests/integration/fixtures/multistage/base",
+                context_path=str(FIXTURES_DIR / "multistage" / "base"),
                 cache_key=base_tag,
             ),
             BuildStage(
                 tag=env_tag,
-                context_path="tests/integration/fixtures/multistage/env",
+                context_path=str(FIXTURES_DIR / "multistage" / "env"),
                 parent_tag=base_tag,
                 cache_key=env_tag,
             ),
             BuildStage(
                 tag=instance_tag,
-                context_path="tests/integration/fixtures/multistage/instance",
+                context_path=str(FIXTURES_DIR / "multistage" / "instance"),
                 parent_tag=env_tag,
             ),
         ]
@@ -842,57 +957,69 @@ class TestMultiStageBuild:
             network_config=None,
         )
 
-        docker = Docker()
-        try:
-            # Cleanup any existing images
+        # Cleanup any existing images (only for local)
+        if docker_client_type == "local":
+            assert docker_client is not None
             for tag in [base_tag, env_tag, instance_tag]:
                 try:
-                    await docker.images.delete(tag, force=True)
+                    await docker_client.images.delete(tag, force=True)
                 except Exception:  # noqa: PERF203
                     pass
 
-            async with manager.setup_batch([task_setup]):
-                # Verify all three images were created
-                images = await docker.images.list()
+        async with manager.setup_batch([task_setup]):
+            # Verify all three images were created (only for local)
+            if docker_client_type == "local":
+                assert docker_client is not None
+                images = await docker_client.images.list()
                 image_tags = [tag for img in images for tag in img.get("RepoTags", [])]
 
                 assert any(base_tag in (tag or "") for tag in image_tags)
                 assert any(env_tag in (tag or "") for tag in image_tags)
                 assert any(instance_tag in (tag or "") for tag in image_tags)
 
-                # Create container and verify all stages executed
-                async with manager.setup_task(task_setup) as sandbox_state:
-                    container_id = sandbox_state.agent_container_id
+            # Create container and verify all stages executed
+            async with manager.setup_task(task_setup) as sandbox_state:
+                container_id = sandbox_state.agent_container_id
 
-                    # Verify base stage
-                    result = await manager.exec(container_id, ["cat", "/base-marker.txt"])
-                    assert result.exit_code == 0
-                    assert result.stdout is not None
-                    assert "Base stage built" in result.stdout
+                # Verify base stage
+                result = await manager.exec(container_id, ["cat", "/base-marker.txt"])
+                assert result.exit_code == 0
+                assert result.stdout is not None
+                assert "Base stage built" in result.stdout
 
-                    # Verify env stage
-                    result = await manager.exec(container_id, ["cat", "/env-marker.txt"])
-                    assert result.exit_code == 0
-                    assert result.stdout is not None
-                    assert "Environment ready" in result.stdout
+                # Verify env stage
+                result = await manager.exec(container_id, ["cat", "/env-marker.txt"])
+                assert result.exit_code == 0
+                assert result.stdout is not None
+                assert "Environment ready" in result.stdout
 
-                    # Verify instance stage
-                    result = await manager.exec(container_id, ["cat", "/instance-marker.txt"])
-                    assert result.exit_code == 0
-                    assert result.stdout is not None
-                    assert "Instance ready" in result.stdout
-        finally:
-            # Cleanup
+                # Verify instance stage
+                result = await manager.exec(container_id, ["cat", "/instance-marker.txt"])
+                assert result.exit_code == 0
+                assert result.stdout is not None
+                assert "Instance ready" in result.stdout
+
+        # Cleanup (only for local)
+        if docker_client_type == "local":
+            assert docker_client is not None
             for tag in [base_tag, env_tag, instance_tag]:
                 try:
-                    await docker.images.delete(tag, force=True)
+                    await docker_client.images.delete(tag, force=True)
                 except Exception:  # noqa: PERF203
                     pass
-            await docker.close()
 
-    async def test_multi_stage_build_caching(self):
+    async def test_multi_stage_build_caching(
+        self,
+        multistage_test_images: list[str],
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        docker_client: AbstractDockerClient | None,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
         """Test that multi-stage build properly caches intermediate stages."""
-        config = DockerSandboxConfig(network_enabled=False)
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=multistage_test_images
+        )
         manager = DockerSandboxManager(config)
 
         base_tag = "test-multistage-cache-base:latest"
@@ -902,18 +1029,18 @@ class TestMultiStageBuild:
         stages = [
             BuildStage(
                 tag=base_tag,
-                context_path="tests/integration/fixtures/multistage/base",
+                context_path=str(FIXTURES_DIR / "multistage" / "base"),
                 cache_key=base_tag,
             ),
             BuildStage(
                 tag=env_tag,
-                context_path="tests/integration/fixtures/multistage/env",
+                context_path=str(FIXTURES_DIR / "multistage" / "env"),
                 parent_tag=base_tag,
                 cache_key=env_tag,
             ),
             BuildStage(
                 tag=instance_tag,
-                context_path="tests/integration/fixtures/multistage/instance",
+                context_path=str(FIXTURES_DIR / "multistage" / "instance"),
                 parent_tag=env_tag,
             ),
         ]
@@ -923,72 +1050,89 @@ class TestMultiStageBuild:
         container_spec = ContainerSpec(image_spec=multi_stage_spec)
         agent_container = ContainerSetup(name="agent", spec=container_spec)
 
-        docker = Docker()
-        try:
-            # Cleanup any existing images
+        # Cleanup any existing images (only for local)
+        if docker_client_type == "local":
+            assert docker_client is not None
             for tag in [base_tag, env_tag, instance_tag]:
                 try:
-                    await docker.images.delete(tag, force=True)
+                    await docker_client.images.delete(tag, force=True)
                 except Exception:  # noqa: PERF203
                     pass
 
-            # First build - all stages should be built
-            task_setup1 = TaskSetup(
-                task_id="cache-test-1",
-                agent_container=agent_container,
-                service_containers={},
-                network_config=None,
-            )
+        # First build - all stages should be built
+        task_setup1 = TaskSetup(
+            task_id="cache-test-1",
+            agent_container=agent_container,
+            service_containers={},
+            network_config=None,
+        )
 
-            async with manager.setup_batch([task_setup1]):
-                images = await docker.images.list()
+        async with manager.setup_batch([task_setup1]):
+            # Verify all images created (only for local)
+            if docker_client_type == "local":
+                assert docker_client is not None
+                images = await docker_client.images.list()
                 image_tags = [tag for img in images for tag in img.get("RepoTags", [])]
 
                 assert any(base_tag in (tag or "") for tag in image_tags)
                 assert any(env_tag in (tag or "") for tag in image_tags)
                 assert any(instance_tag in (tag or "") for tag in image_tags)
 
-            # Delete only instance image
-            await docker.images.delete(instance_tag, force=True)
+        # Delete only instance image (only for local)
+        if docker_client_type == "local":
+            assert docker_client is not None
+            await docker_client.images.delete(instance_tag, force=True)
 
-            # Second build - base and env should be cached
-            task_setup2 = TaskSetup(
-                task_id="cache-test-2",
-                agent_container=agent_container,
-                service_containers={},
-                network_config=None,
-            )
+        # Second build - base and env should be cached
+        task_setup2 = TaskSetup(
+            task_id="cache-test-2",
+            agent_container=agent_container,
+            service_containers={},
+            network_config=None,
+        )
 
-            async with manager.setup_batch([task_setup2]):
-                # Verify all images exist again
-                images = await docker.images.list()
+        async with manager.setup_batch([task_setup2]):
+            # Verify all images exist again (only for local)
+            if docker_client_type == "local":
+                assert docker_client is not None
+                images = await docker_client.images.list()
                 image_tags = [tag for img in images for tag in img.get("RepoTags", [])]
 
                 assert any(base_tag in (tag or "") for tag in image_tags)
                 assert any(env_tag in (tag or "") for tag in image_tags)
                 assert any(instance_tag in (tag or "") for tag in image_tags)
 
-                # Verify functionality
-                async with manager.setup_task(task_setup2) as sandbox_state:
-                    result = await manager.exec(
-                        sandbox_state.agent_container_id,
-                        ["cat", "/instance-marker.txt"],
-                    )
-                    assert result.exit_code == 0
-                    assert result.stdout is not None
-                    assert "Instance ready" in result.stdout
-        finally:
-            # Cleanup
+            # Verify functionality
+            async with manager.setup_task(task_setup2) as sandbox_state:
+                result = await manager.exec(
+                    sandbox_state.agent_container_id,
+                    ["cat", "/instance-marker.txt"],
+                )
+                assert result.exit_code == 0
+                assert result.stdout is not None
+                assert "Instance ready" in result.stdout
+
+        # Cleanup (only for local)
+        if docker_client_type == "local":
+            assert docker_client is not None
             for tag in [base_tag, env_tag, instance_tag]:
                 try:
-                    await docker.images.delete(tag, force=True)
+                    await docker_client.images.delete(tag, force=True)
                 except Exception:  # noqa: PERF203
                     pass
-            await docker.close()
 
-    async def test_shared_base_and_env_stages(self):
+    async def test_shared_base_and_env_stages(
+        self,
+        multistage_test_images: list[str],
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        docker_client: AbstractDockerClient | None,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
         """Test multiple instances sharing base and env stages."""
-        config = DockerSandboxConfig(network_enabled=False)
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=multistage_test_images
+        )
         manager = DockerSandboxManager(config)
 
         base_tag = "test-shared-base:latest"
@@ -1001,18 +1145,18 @@ class TestMultiStageBuild:
             stages=[
                 BuildStage(
                     tag=base_tag,
-                    context_path="tests/integration/fixtures/multistage/base",
+                    context_path=str(FIXTURES_DIR / "multistage" / "base"),
                     cache_key=base_tag,
                 ),
                 BuildStage(
                     tag=env_tag,
-                    context_path="tests/integration/fixtures/multistage/env",
+                    context_path=str(FIXTURES_DIR / "multistage" / "env"),
                     parent_tag=base_tag,
                     cache_key=env_tag,
                 ),
                 BuildStage(
                     tag=instance1_tag,
-                    context_path="tests/integration/fixtures/multistage/instance",
+                    context_path=str(FIXTURES_DIR / "multistage" / "instance"),
                     parent_tag=env_tag,
                 ),
             ],
@@ -1023,18 +1167,18 @@ class TestMultiStageBuild:
             stages=[
                 BuildStage(
                     tag=base_tag,
-                    context_path="tests/integration/fixtures/multistage/base",
+                    context_path=str(FIXTURES_DIR / "multistage" / "base"),
                     cache_key=base_tag,
                 ),
                 BuildStage(
                     tag=env_tag,
-                    context_path="tests/integration/fixtures/multistage/env",
+                    context_path=str(FIXTURES_DIR / "multistage" / "env"),
                     parent_tag=base_tag,
                     cache_key=env_tag,
                 ),
                 BuildStage(
                     tag=instance2_tag,
-                    context_path="tests/integration/fixtures/multistage/instance",
+                    context_path=str(FIXTURES_DIR / "multistage" / "instance"),
                     parent_tag=env_tag,
                 ),
             ],
@@ -1062,18 +1206,20 @@ class TestMultiStageBuild:
             ),
         ]
 
-        docker = Docker()
-        try:
-            # Cleanup
+        # Cleanup (only for local)
+        if docker_client_type == "local":
+            assert docker_client is not None
             for tag in [base_tag, env_tag, instance1_tag, instance2_tag]:
                 try:
-                    await docker.images.delete(tag, force=True)
+                    await docker_client.images.delete(tag, force=True)
                 except Exception:  # noqa: PERF203
                     pass
 
-            async with manager.setup_batch(task_setups):
-                # Verify all images created
-                images = await docker.images.list()
+        async with manager.setup_batch(task_setups):
+            # Verify all images created (only for local)
+            if docker_client_type == "local":
+                assert docker_client is not None
+                images = await docker_client.images.list()
                 image_tags = [tag for img in images for tag in img.get("RepoTags", [])]
 
                 # Base and env should exist (built once)
@@ -1084,25 +1230,337 @@ class TestMultiStageBuild:
                 assert any(instance1_tag in (tag or "") for tag in image_tags)
                 assert any(instance2_tag in (tag or "") for tag in image_tags)
 
-                # Verify both work
-                async with manager.setup_task(task_setups[0]) as state1:
-                    result = await manager.exec(
-                        state1.agent_container_id,
-                        ["cat", "/base-marker.txt"],
-                    )
-                    assert result.exit_code == 0
+            # Verify both work
+            async with manager.setup_task(task_setups[0]) as state1:
+                result = await manager.exec(
+                    state1.agent_container_id,
+                    ["cat", "/base-marker.txt"],
+                )
+                assert result.exit_code == 0
 
-                async with manager.setup_task(task_setups[1]) as state2:
-                    result = await manager.exec(
-                        state2.agent_container_id,
-                        ["cat", "/env-marker.txt"],
-                    )
-                    assert result.exit_code == 0
-        finally:
-            # Cleanup
+            async with manager.setup_task(task_setups[1]) as state2:
+                result = await manager.exec(
+                    state2.agent_container_id,
+                    ["cat", "/env-marker.txt"],
+                )
+                assert result.exit_code == 0
+
+        # Cleanup (only for local)
+        if docker_client_type == "local":
+            assert docker_client is not None
             for tag in [base_tag, env_tag, instance1_tag, instance2_tag]:
                 try:
-                    await docker.images.delete(tag, force=True)
+                    await docker_client.images.delete(tag, force=True)
                 except Exception:  # noqa: PERF203
                     pass
-            await docker.close()
+
+
+# ==================== Stdin Handling Tests ====================
+
+
+@pytest.mark.docker_integration
+class TestStdinHandling:
+    """Integration tests for stdin handling in Docker exec operations."""
+
+    async def test_exec_with_stdin_string(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
+        """Test executing a command with stdin as string."""
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
+        manager = DockerSandboxManager(config)
+
+        container_spec = ContainerSpec(image_spec=PullImageSpec(tag=test_image))
+        agent_container = ContainerSetup(name="agent", spec=container_spec)
+        task_setup = TaskSetup(
+            task_id="stdin-string-test",
+            agent_container=agent_container,
+            service_containers={},
+            network_config=None,
+        )
+
+        async with manager.setup_batch([task_setup]):
+            async with manager.setup_task(task_setup) as state:
+                # Execute cat command with stdin - should echo back the input
+                result = await manager.exec(
+                    state.agent_container_id,
+                    ["cat"],
+                    stdin="Hello, World!\nThis is a test.",
+                )
+
+                assert result.exit_code == 0
+                assert result.stdout is not None
+                assert "Hello, World!" in result.stdout
+                assert "This is a test." in result.stdout
+
+    async def test_exec_with_stdin_bytes(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
+        """Test executing a command with stdin as bytes."""
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
+        manager = DockerSandboxManager(config)
+
+        container_spec = ContainerSpec(image_spec=PullImageSpec(tag=test_image))
+        agent_container = ContainerSetup(name="agent", spec=container_spec)
+        task_setup = TaskSetup(
+            task_id="stdin-bytes-test",
+            agent_container=agent_container,
+            service_containers={},
+            network_config=None,
+        )
+
+        async with manager.setup_batch([task_setup]):
+            async with manager.setup_task(task_setup) as state:
+                # Execute cat command with bytes stdin
+                test_data = b"Binary test data\nWith multiple lines"
+                result = await manager.exec(
+                    state.agent_container_id,
+                    ["cat"],
+                    stdin=test_data,
+                )
+
+                assert result.exit_code == 0
+                assert result.stdout is not None
+                assert "Binary test data" in result.stdout
+                assert "With multiple lines" in result.stdout
+
+    async def test_exec_with_stdin_special_characters(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
+        """Test executing a command with stdin containing special characters."""
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
+        manager = DockerSandboxManager(config)
+
+        container_spec = ContainerSpec(image_spec=PullImageSpec(tag=test_image))
+        agent_container = ContainerSetup(name="agent", spec=container_spec)
+        task_setup = TaskSetup(
+            task_id="stdin-special-chars-test",
+            agent_container=agent_container,
+            service_containers={},
+            network_config=None,
+        )
+
+        async with manager.setup_batch([task_setup]):
+            async with manager.setup_task(task_setup) as state:
+                # Test with special characters including single quotes, double quotes, backticks
+                special_input = (
+                    "Line with 'single quotes'\nLine with \"double quotes\"\nLine with `backticks`"
+                )
+                result = await manager.exec(
+                    state.agent_container_id,
+                    ["cat"],
+                    stdin=special_input,
+                )
+
+                assert result.exit_code == 0
+                assert result.stdout is not None
+                # Verify all special characters are preserved
+                assert "'single quotes'" in result.stdout or "single quotes" in result.stdout
+                assert '"double quotes"' in result.stdout or "double quotes" in result.stdout
+                assert "`backticks`" in result.stdout or "backticks" in result.stdout
+
+    async def test_exec_with_stdin_multiline(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
+        """Test executing a command with multiline stdin."""
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
+        manager = DockerSandboxManager(config)
+
+        container_spec = ContainerSpec(image_spec=PullImageSpec(tag=test_image))
+        agent_container = ContainerSetup(name="agent", spec=container_spec)
+        task_setup = TaskSetup(
+            task_id="stdin-multiline-test",
+            agent_container=agent_container,
+            service_containers={},
+            network_config=None,
+        )
+
+        async with manager.setup_batch([task_setup]):
+            async with manager.setup_task(task_setup) as state:
+                # Test with multiline input
+                multiline_input = "line 1\nline 2\nline 3\nline 4\nline 5"
+                result = await manager.exec(
+                    state.agent_container_id,
+                    ["cat"],
+                    stdin=multiline_input,
+                )
+
+                assert result.exit_code == 0
+                assert result.stdout is not None
+                assert "line 1" in result.stdout
+                assert "line 2" in result.stdout
+                assert "line 3" in result.stdout
+                assert "line 4" in result.stdout
+                assert "line 5" in result.stdout
+
+    async def test_exec_with_stdin_piped_to_command(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
+        """Test stdin being properly piped to a command that processes it."""
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
+        manager = DockerSandboxManager(config)
+
+        container_spec = ContainerSpec(image_spec=PullImageSpec(tag=test_image))
+        agent_container = ContainerSetup(name="agent", spec=container_spec)
+        task_setup = TaskSetup(
+            task_id="stdin-piped-test",
+            agent_container=agent_container,
+            service_containers={},
+            network_config=None,
+        )
+
+        async with manager.setup_batch([task_setup]):
+            async with manager.setup_task(task_setup) as state:
+                # Use a command that processes stdin (word count)
+                # Note: wc -l counts newline characters, so input must end with \n
+                test_input = "line one\nline two\nline three\n"
+                result = await manager.exec(
+                    state.agent_container_id,
+                    ["wc", "-l"],
+                    stdin=test_input,
+                )
+
+                assert result.exit_code == 0
+                assert result.stdout is not None
+                # Should count 3 lines (3 newline characters)
+                assert "3" in result.stdout
+
+    async def test_exec_with_stdin_empty_string(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
+        """Test executing a command with empty stdin."""
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
+        manager = DockerSandboxManager(config)
+
+        container_spec = ContainerSpec(image_spec=PullImageSpec(tag=test_image))
+        agent_container = ContainerSetup(name="agent", spec=container_spec)
+        task_setup = TaskSetup(
+            task_id="stdin-empty-test",
+            agent_container=agent_container,
+            service_containers={},
+            network_config=None,
+        )
+
+        async with manager.setup_batch([task_setup]):
+            async with manager.setup_task(task_setup) as state:
+                # Execute cat command with empty stdin
+                result = await manager.exec(
+                    state.agent_container_id,
+                    ["cat"],
+                    stdin="",
+                )
+
+                assert result.exit_code == 0
+                # Empty stdin should result in empty output
+                assert result.stdout is None
+
+    async def test_exec_with_stdin_large_input(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
+        """Test executing a command with large stdin input."""
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
+        manager = DockerSandboxManager(config)
+
+        container_spec = ContainerSpec(image_spec=PullImageSpec(tag=test_image))
+        agent_container = ContainerSetup(name="agent", spec=container_spec)
+        task_setup = TaskSetup(
+            task_id="stdin-large-test",
+            agent_container=agent_container,
+            service_containers={},
+            network_config=None,
+        )
+
+        async with manager.setup_batch([task_setup]):
+            async with manager.setup_task(task_setup) as state:
+                # Create a large input (10KB)
+                large_input = "A" * 10000 + "\n"
+                result = await manager.exec(
+                    state.agent_container_id,
+                    ["wc", "-c"],
+                    stdin=large_input,
+                )
+
+                assert result.exit_code == 0
+                assert result.stdout is not None
+                # Should count ~10001 bytes (10000 A's + 1 newline)
+                assert "10001" in result.stdout
+
+    async def test_exec_with_stdin_and_environment(
+        self,
+        test_image: str,
+        docker_client_type: str,
+        skip_if_des_unavailable,
+        create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
+    ):
+        """Test executing a command with both stdin and environment variables."""
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=test_image
+        )
+        manager = DockerSandboxManager(config)
+
+        container_spec = ContainerSpec(image_spec=PullImageSpec(tag=test_image))
+        agent_container = ContainerSetup(name="agent", spec=container_spec)
+        task_setup = TaskSetup(
+            task_id="stdin-env-test",
+            agent_container=agent_container,
+            service_containers={},
+            network_config=None,
+        )
+
+        async with manager.setup_batch([task_setup]):
+            async with manager.setup_task(task_setup) as state:
+                # Execute a script that uses both stdin and env var
+                stdin_data = "input from stdin"
+                result = await manager.exec(
+                    state.agent_container_id,
+                    ["sh", "-c", "echo ENV: $TEST_VAR && cat"],
+                    stdin=stdin_data,
+                    env={"TEST_VAR": "test_value"},
+                )
+
+                assert result.exit_code == 0
+                assert result.stdout is not None
+                # Should see both the env var and stdin content
+                assert "ENV: test_value" in result.stdout
+                assert "input from stdin" in result.stdout

--- a/tests/integration/test_swebench_tools_integration.py
+++ b/tests/integration/test_swebench_tools_integration.py
@@ -6,7 +6,7 @@ Run with: pytest -vx -m docker_integration
 Skip with: pytest -vx -m "not docker_integration"
 """
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from uuid import uuid4
 
@@ -45,12 +45,17 @@ pytestmark = pytest.mark.anyio
 @pytest.fixture(scope="module")
 async def sandbox_manager(
     test_image: str,
+    docker_client_type: str,
+    skip_if_des_unavailable,
+    create_manager_config: Callable[[str, bool, str | list[str] | None], DockerSandboxConfig],
 ) -> AsyncIterator[tuple[AbstractSandboxManager, str, TaskSetup]]:
     """Create a sandbox manager for tool testing.
 
     Returns tuple of (sandbox_manager, test_image, task_setup) for use by dependent fixtures.
     """
-    config = DockerSandboxConfig(network_enabled=False)
+    config = create_manager_config(
+        docker_client_type, network_enabled=False, test_images=test_image
+    )
     manager = DockerSandboxManager(config)
 
     # Create TaskSetup for API

--- a/tests/sandbox_managers/docker/plugins/__init__.py
+++ b/tests/sandbox_managers/docker/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Docker client plugin tests."""

--- a/tests/sandbox_managers/docker/plugins/test_local_client.py
+++ b/tests/sandbox_managers/docker/plugins/test_local_client.py
@@ -1,0 +1,467 @@
+"""Unit tests for LocalDockerClient."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from prompt_siren.sandbox_managers.abstract import ExecOutput
+from prompt_siren.sandbox_managers.docker.plugins.local_client import (
+    LocalContainer,
+    LocalDockerClient,
+    LocalNetwork,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def mock_docker():
+    """Create a mock aiodocker.Docker instance."""
+    docker = MagicMock()
+    docker.close = AsyncMock()
+    docker.images = MagicMock()
+    docker.images.inspect = AsyncMock()
+    docker.images.pull = AsyncMock()
+    docker.images.build = AsyncMock()
+    docker.images.delete = AsyncMock()
+    docker.containers = MagicMock()
+    docker.containers.create = AsyncMock()
+    docker.containers.get = AsyncMock()
+    docker.networks = MagicMock()
+    docker.networks.create = AsyncMock()
+    docker.networks.get = AsyncMock()
+    return docker
+
+
+@pytest.fixture
+def client(mock_docker):
+    """Create a LocalDockerClient with mocked aiodocker."""
+    with patch(
+        "prompt_siren.sandbox_managers.docker.plugins.local_client.aiodocker.Docker"
+    ) as mock_cls:
+        mock_cls.return_value = mock_docker
+        client = LocalDockerClient()
+        client._docker = mock_docker
+        return client
+
+
+class TestLocalDockerClient:
+    """Tests for LocalDockerClient."""
+
+    async def test_close(self, client, mock_docker):
+        """Test closing the client."""
+        await client.close()
+        mock_docker.close.assert_awaited_once()
+
+    async def test_inspect_image(self, client, mock_docker):
+        """Test inspecting an image."""
+        mock_docker.images.inspect.return_value = {"Id": "sha256:abc123"}
+
+        result = await client.inspect_image("python:3.12")
+
+        mock_docker.images.inspect.assert_awaited_once_with("python:3.12")
+        assert result == {"Id": "sha256:abc123"}
+
+    async def test_pull_image(self, client, mock_docker):
+        """Test pulling an image."""
+        await client.pull_image("python:3.12")
+
+        mock_docker.images.pull.assert_awaited_once_with(from_image="python:3.12")
+
+    async def test_build_image(self, client, mock_docker):
+        """Test building an image."""
+
+        # Mock build stream
+        async def mock_build(*args, **kwargs):
+            yield {"stream": "Step 1/2 : FROM python:3.12"}
+            yield {"stream": "Step 2/2 : RUN echo hello"}
+
+        mock_docker.images.build = mock_build
+
+        # Mock tarfile to avoid filesystem access
+        with patch(
+            "prompt_siren.sandbox_managers.docker.plugins.local_client.tarfile.open"
+        ) as mock_tar_open:
+            mock_tar = MagicMock()
+            mock_tar_open.return_value.__enter__.return_value = mock_tar
+
+            logs = []
+            async for log in client.build_image(
+                context_path="/tmp/test",
+                tag="test:latest",
+                dockerfile_path="Dockerfile",
+                buildargs={"ARG1": "value1"},
+            ):
+                logs.append(log)
+
+            assert len(logs) == 2
+            assert "Step 1/2" in logs[0]["stream"]
+            assert "Step 2/2" in logs[1]["stream"]
+            # Verify tar.add was called with the context path
+            mock_tar.add.assert_called_once()
+
+    async def test_delete_image(self, client, mock_docker):
+        """Test deleting an image."""
+        await client.delete_image("test:latest", force=True)
+
+        mock_docker.images.delete.assert_awaited_once_with("test:latest", force=True)
+
+    async def test_create_container(self, client, mock_docker):
+        """Test creating a container."""
+        mock_container = MagicMock()
+        mock_docker.containers.create.return_value = mock_container
+
+        config = {"Image": "python:3.12"}
+        container = await client.create_container(config, name="test-container")
+
+        mock_docker.containers.create.assert_awaited_once_with(config, name="test-container")
+        assert isinstance(container, LocalContainer)
+
+    async def test_get_container(self, client, mock_docker):
+        """Test getting a container."""
+        mock_container = MagicMock()
+        mock_docker.containers.get.return_value = mock_container
+
+        container = await client.get_container("container123")
+
+        mock_docker.containers.get.assert_awaited_once_with("container123")
+        assert isinstance(container, LocalContainer)
+
+    async def test_create_network(self, client, mock_docker):
+        """Test creating a network."""
+        mock_network = MagicMock()
+        mock_docker.networks.create.return_value = mock_network
+
+        config = {"Name": "test-network", "Driver": "bridge"}
+        network = await client.create_network(config)
+
+        mock_docker.networks.create.assert_awaited_once_with(config=config)
+        assert isinstance(network, LocalNetwork)
+
+    async def test_get_network(self, client, mock_docker):
+        """Test getting a network."""
+        mock_network = MagicMock()
+        mock_docker.networks.get.return_value = mock_network
+
+        network = await client.get_network("network123")
+
+        mock_docker.networks.get.assert_awaited_once_with("network123")
+        assert isinstance(network, LocalNetwork)
+
+
+class TestLocalContainer:
+    """Tests for LocalContainer wrapper."""
+
+    async def test_start(self):
+        """Test starting a container."""
+        mock_container = MagicMock()
+        mock_container.start = AsyncMock()
+        container = LocalContainer(mock_container)
+
+        await container.start()
+
+        mock_container.start.assert_awaited_once()
+
+    async def test_stop(self):
+        """Test stopping a container."""
+        mock_container = MagicMock()
+        mock_container.stop = AsyncMock()
+        container = LocalContainer(mock_container)
+
+        await container.stop()
+
+        mock_container.stop.assert_awaited_once()
+
+    async def test_delete(self):
+        """Test deleting a container."""
+        mock_container = MagicMock()
+        mock_container.delete = AsyncMock()
+        container = LocalContainer(mock_container)
+
+        await container.delete()
+
+        mock_container.delete.assert_awaited_once()
+
+    async def test_show(self):
+        """Test showing container details."""
+        mock_container = MagicMock()
+        mock_container.show = AsyncMock(return_value={"Id": "abc123", "State": {"Running": True}})
+        container = LocalContainer(mock_container)
+
+        info = await container.show()
+
+        assert info["Id"] == "abc123"
+        assert info["State"]["Running"] is True
+
+    async def test_exec(self):
+        """Test executing a command."""
+        # Mock the exec instance and stream
+        mock_msg = MagicMock()
+        mock_msg.stream = 1
+        mock_msg.data = b"hello\n"
+
+        mock_stream = MagicMock()
+        mock_stream.read_out = AsyncMock(side_effect=[mock_msg, None])
+        mock_stream.write_in = AsyncMock()
+        mock_stream._resp = MagicMock()
+        mock_stream._resp.connection = MagicMock()
+        mock_stream._resp.connection.transport = None
+
+        mock_exec = MagicMock()
+        mock_exec.start = MagicMock(return_value=mock_stream)
+        mock_exec.inspect = AsyncMock(return_value={"ExitCode": 0})
+
+        mock_container = MagicMock()
+        mock_container.exec = AsyncMock(return_value=mock_exec)
+        container = LocalContainer(mock_container)
+
+        result = await container.exec(
+            cmd=["bash", "-c", "echo hello"],
+            stdin=None,
+            user="root",
+            environment={"VAR": "value"},
+            workdir="/app",
+            timeout=30,
+        )
+
+        assert isinstance(result, ExecOutput)
+        assert result.exit_code == 0
+        assert result.stdout == "hello\n"
+        mock_container.exec.assert_awaited_once()
+
+    async def test_log(self):
+        """Test getting container logs."""
+        mock_container = MagicMock()
+        mock_container.log = AsyncMock(return_value=["line1\n", "line2\n"])
+        container = LocalContainer(mock_container)
+
+        logs = await container.log(stdout=True, stderr=True)
+
+        assert logs == ["line1\n", "line2\n"]
+
+    async def test_commit(self):
+        """Test committing a container."""
+        mock_container = MagicMock()
+        mock_container.commit = AsyncMock()
+        container = LocalContainer(mock_container)
+
+        await container.commit(repository="test-image", tag="latest")
+
+        mock_container.commit.assert_awaited_once_with(repository="test-image", tag="latest")
+
+
+class TestLocalNetwork:
+    """Tests for LocalNetwork wrapper."""
+
+    async def test_show(self):
+        """Test showing network details."""
+        mock_network = MagicMock()
+        mock_network.show = AsyncMock(return_value={"Id": "net123", "Driver": "bridge"})
+        network = LocalNetwork(mock_network)
+
+        info = await network.show()
+
+        assert info["Id"] == "net123"
+        assert info["Driver"] == "bridge"
+
+    async def test_delete(self):
+        """Test deleting a network."""
+        mock_network = MagicMock()
+        mock_network.delete = AsyncMock()
+        network = LocalNetwork(mock_network)
+
+        await network.delete()
+
+        mock_network.delete.assert_awaited_once()
+
+
+@pytest.mark.docker_integration
+class TestLocalDockerClientIntegration:
+    """Integration tests for LocalDockerClient that use actual Docker daemon."""
+
+    async def test_client_lifecycle(self):
+        """Test creating and closing a client."""
+        client = LocalDockerClient()
+
+        try:
+            # Verify client is initialized
+            assert client._docker is not None
+        finally:
+            await client.close()
+
+    async def test_container_lifecycle(self):
+        """Test creating, starting, stopping, and deleting a container."""
+        client = LocalDockerClient()
+
+        try:
+            # Create container
+            config = {
+                "Image": "vmvm-registry.fbinfra.net/debian:bookworm-slim",
+                "Cmd": ["sleep", "300"],
+            }
+            container = await client.create_container(config, name="test-local-container-lifecycle")
+
+            try:
+                # Start container
+                await container.start()
+
+                # Check container is running
+                info = await container.show()
+                assert info["State"]["Running"] is True
+
+                # Stop container
+                await container.stop()
+
+                # Verify stopped
+                info = await container.show()
+                assert info["State"]["Running"] is False
+            finally:
+                # Clean up container
+                await container.delete()
+        finally:
+            await client.close()
+
+    async def test_exec_command(self):
+        """Test executing a command in a container."""
+        client = LocalDockerClient()
+
+        try:
+            # Create and start container
+            config = {
+                "Image": "vmvm-registry.fbinfra.net/debian:bookworm-slim",
+                "Cmd": ["sleep", "300"],
+            }
+            container = await client.create_container(config, name="test-local-exec-command")
+
+            try:
+                await container.start()
+
+                # Execute command
+                result = await container.exec(
+                    cmd=["echo", "hello", "world"],
+                    stdin=None,
+                    user="root",
+                    environment=None,
+                    workdir=None,
+                    timeout=30,
+                )
+
+                # Verify output contains "hello world"
+                assert result.stdout is not None
+                assert "hello world" in result.stdout
+                assert result.exit_code == 0
+            finally:
+                await container.delete()
+        finally:
+            await client.close()
+
+    async def test_network_lifecycle(self):
+        """Test creating and deleting a network."""
+        client = LocalDockerClient()
+
+        try:
+            # Create network
+            config = {
+                "Name": "test-local-network-lifecycle",
+                "Driver": "bridge",
+                "Internal": False,
+            }
+            network = await client.create_network(config)
+
+            try:
+                # Verify network exists
+                info = await network.show()
+                assert info["Name"] == "test-local-network-lifecycle"
+                assert info["Driver"] == "bridge"
+            finally:
+                # Clean up network
+                await network.delete()
+        finally:
+            await client.close()
+
+    async def test_image_operations(self):
+        """Test pulling and inspecting images."""
+        client = LocalDockerClient()
+
+        try:
+            # Pull a small test image
+            await client.pull_image("alpine:latest")
+
+            # Inspect the image
+            image_info = await client.inspect_image("alpine:latest")
+            assert image_info["Id"] is not None
+            assert "alpine" in image_info["RepoTags"][0].lower()
+        finally:
+            await client.close()
+
+    async def test_container_logs(self):
+        """Test getting container logs."""
+        client = LocalDockerClient()
+
+        try:
+            # Create and start container with a command that produces output
+            config = {
+                "Image": "vmvm-registry.fbinfra.net/debian:bookworm-slim",
+                "Cmd": ["sh", "-c", "'echo \"test log output\" && sleep 300'"],
+            }
+            container = await client.create_container(config, name="test-local-container-logs")
+
+            try:
+                await container.start()
+
+                # Wait a bit for the command to execute
+                await asyncio.sleep(2)
+
+                # Get logs
+                logs = await container.log(stdout=True, stderr=True)
+
+                # Verify logs contain expected output
+                log_text = "\n".join(logs)
+                assert "test log output" in log_text
+            finally:
+                await container.delete()
+        finally:
+            await client.close()
+
+    async def test_container_commit(self):
+        """Test committing a container to an image."""
+        client = LocalDockerClient()
+
+        try:
+            # Create and start container
+            config = {
+                "Image": "vmvm-registry.fbinfra.net/debian:bookworm-slim",
+                "Cmd": ["sleep", "300"],
+            }
+            container = await client.create_container(config, name="test-local-container-commit")
+
+            try:
+                await container.start()
+
+                # Make a change in the container
+                await container.exec(
+                    cmd=["sh", "-c", "echo 'test' > /tmp/testfile"],
+                    stdin=None,
+                    user="root",
+                    environment=None,
+                    workdir=None,
+                    timeout=30,
+                )
+
+                # Commit container to new image
+                await container.commit(repository="test-local-committed-image", tag="v1")
+
+                # Verify image exists
+                image_info = await client.inspect_image("test-local-committed-image:v1")
+                assert image_info["Id"] is not None
+            finally:
+                # Clean up
+                await container.delete()
+                try:
+                    await client.delete_image("test-local-committed-image:v1", force=True)
+                except Exception:
+                    pass  # Ignore cleanup errors
+        finally:
+            await client.close()

--- a/tests/sandbox_managers/docker/test_manager.py
+++ b/tests/sandbox_managers/docker/test_manager.py
@@ -12,7 +12,6 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from aiodocker import Docker
 from prompt_siren.sandbox_managers.docker.manager import (
     DockerSandboxConfig,
     DockerSandboxManager,
@@ -53,7 +52,7 @@ class TestDockerSandboxManagerCleanup:
 
     @patch("prompt_siren.sandbox_managers.docker.manager.aiodocker.Docker")
     async def test_setup_batch_cleans_up_contexts(
-        self, mock_docker_cls: Docker, manager: DockerSandboxManager, task_setup: TaskSetup
+        self, mock_docker_cls, manager: DockerSandboxManager, task_setup: TaskSetup
     ):
         """Test that setup_batch cleans up all task contexts on exit."""
         mock_docker = AsyncMock()
@@ -121,7 +120,7 @@ class TestDockerSandboxManagerContextLookup:
 
     @patch("prompt_siren.sandbox_managers.docker.manager.aiodocker.Docker")
     async def test_clone_invalid_execution_id_raises_error(
-        self, mock_docker_cls: Docker, manager: DockerSandboxManager, task_setup: TaskSetup
+        self, mock_docker_cls, manager: DockerSandboxManager, task_setup: TaskSetup
     ):
         """Test that cloning with invalid execution_id raises ValueError."""
         mock_docker = AsyncMock()
@@ -147,7 +146,7 @@ class TestDockerSandboxManagerConcurrency:
 
     @patch("prompt_siren.sandbox_managers.docker.manager.aiodocker.Docker")
     async def test_parallel_tasks_with_same_task_id(
-        self, mock_docker_cls: Docker, manager: DockerSandboxManager, task_setup: TaskSetup
+        self, mock_docker_cls, manager: DockerSandboxManager, task_setup: TaskSetup
     ):
         """Test that parallel tasks with same task_id get unique execution_ids."""
         mock_docker = AsyncMock()
@@ -195,7 +194,7 @@ class TestDockerSandboxManagerCloning:
 
     @patch("prompt_siren.sandbox_managers.docker.manager.aiodocker.Docker")
     async def test_clone_preserves_custom_command(
-        self, mock_docker_cls: Docker, manager: DockerSandboxManager, task_setup: TaskSetup
+        self, mock_docker_cls, manager: DockerSandboxManager, task_setup: TaskSetup
     ):
         """Test that cloning a container preserves custom command."""
         # Setup mock Docker client


### PR DESCRIPTION
Here, we "pluginize" the Docker container client so that users can implement their own Docker utilities as a plugin that does not require changing the codebase. To do so, we moved all `aiodocker` functionality under the newly-created `local_client.py` Docker plugin and also abstracted away errors being thrown. 