### PR TITLE
Fix Docker integration tests

### DIFF
--- a/tests/integration/test_docker_manager_integration.py
+++ b/tests/integration/test_docker_manager_integration.py
@@ -9,17 +9,17 @@ Skip with: pytest -vx -m "not docker_integration"
 """
 
 import asyncio
+import contextlib
+import logging
 from collections.abc import AsyncIterator
 from pathlib import Path
 from uuid import uuid4
 
 import pytest
 from prompt_siren.sandbox_managers.abstract import AbstractSandboxManager
-from prompt_siren.sandbox_managers.docker.local_client import LocalDockerClient
 from prompt_siren.sandbox_managers.docker.manager import (
     DockerSandboxManager,
 )
-from prompt_siren.sandbox_managers.docker.plugins import AbstractDockerClient
 from prompt_siren.sandbox_managers.image_spec import (
     BuildImageSpec,
     BuildStage,
@@ -33,6 +33,8 @@ from prompt_siren.sandbox_managers.sandbox_task_setup import (
     NetworkConfig,
     TaskSetup,
 )
+
+logger = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.anyio
 
@@ -227,8 +229,17 @@ class TestMultiContainerNetworking:
         test_image: str,
         docker_client_type: str,
         create_manager_config,
+        docker_client,
     ):
         """Test that containers on the same network can resolve each other by hostname."""
+        # PRE-TEST CLEANUP: Remove any existing test image
+        # Use docker_client fixture ONLY for pre-cleanup
+        try:
+            await docker_client.delete_image("prompt-siren-network-test:latest", force=True)
+        except Exception:
+            pass  # Image might not exist, that's fine
+
+        # Now create manager and run the actual test
         config = create_manager_config(
             docker_client_type, network_enabled=True, test_images=test_image
         )
@@ -300,7 +311,6 @@ class TestMultiContainerNetworking:
         self,
         test_image: str,
         docker_client_type: str,
-        docker_client: AbstractDockerClient | None,
         create_manager_config,
     ):
         """Test that network_enabled=False creates internal-only network for multi-container."""
@@ -328,8 +338,9 @@ class TestMultiContainerNetworking:
                 # Verify network was created (needed for multi-container)
                 assert sandbox_state.network_id is not None
 
-                # Verify network is internal by inspecting it
-                assert docker_client is not None
+                # Verify network is internal by inspecting it using manager's docker client
+                assert manager._batch_state is not None
+                docker_client = manager._batch_state.docker_client
                 network = await docker_client.get_network(sandbox_state.network_id)
                 network_info = await network.show()
                 assert network_info["Internal"] is True
@@ -405,7 +416,6 @@ class TestContainerCloning:
         self,
         test_image: str,
         docker_client_type: str,
-        docker_client: AbstractDockerClient | None,
         create_manager_config,
     ):
         """Test cloning a container with custom command preserves and runs the command."""
@@ -436,16 +446,23 @@ class TestContainerCloning:
             async with manager.setup_task(task_setup) as source_state:
                 source_id = source_state.agent_container_id
 
-                # Verify source container's command via Docker API
-                assert docker_client is not None
-                source_container = await docker_client.get_container(source_id)
-                source_info = await source_container.show()
-                source_cmd = source_info["Config"]["Cmd"]
-                assert source_cmd == custom_command
+                # Verify source container's command by checking PID 1's cmdline
+                # PID 1 is the main process started with the container's command
+                await asyncio.sleep(0.5)  # Give process time to start
+                source_pid1_result = await manager.exec(
+                    source_id,
+                    ["cat", "/proc/1/cmdline"],
+                )
+                assert source_pid1_result.exit_code == 0
+                assert source_pid1_result.stdout is not None
+                # cmdline uses null bytes as separators, check for our command components
+                source_cmdline = source_pid1_result.stdout
+                logger.info(f"Source container PID 1 cmdline: {source_cmdline!r}")
+                assert "/bin/bash" in source_cmdline
+                assert "custom-process-marker" in source_cmdline
 
                 # Verify command is actually running in source container
                 # Use /proc filesystem which is available in all Linux containers
-                await asyncio.sleep(0.5)  # Give process time to start
                 cmdline_result = await manager.exec(
                     source_id,
                     ["sh", "-c", "cat /proc/*/cmdline | tr '\\0' '\\n'"],
@@ -461,18 +478,28 @@ class TestContainerCloning:
                 # Verify clone has different container ID
                 assert cloned_id != source_id
 
-                # Verify cloned container's command via Docker API
-                assert docker_client is not None
-                cloned_container = await docker_client.get_container(cloned_id)
-                cloned_info = await cloned_container.show()
-                cloned_cmd = cloned_info["Config"]["Cmd"]
-                assert cloned_cmd == custom_command
+                # Verify cloned container's command by checking PID 1's cmdline
+                cloned_pid1_result = await manager.exec(
+                    cloned_id,
+                    ["cat", "/proc/1/cmdline"],
+                )
+                assert cloned_pid1_result.exit_code == 0
+                assert cloned_pid1_result.stdout is not None
+                cloned_cmdline = cloned_pid1_result.stdout
+                assert "/bin/bash" in cloned_cmdline
+                assert "custom-process-marker" in cloned_cmdline
 
-                # Re-fetch source_info to verify both containers are running
-                source_container = await docker_client.get_container(source_id)
-                source_info_check = await source_container.show()
-                assert source_info_check["State"]["Running"] is True
-                assert cloned_info["State"]["Running"] is True
+                # Verify both containers are running by executing commands in them
+                # If exec succeeds, the container is running
+                source_check = await manager.exec(source_id, ["echo", "source-alive"])
+                assert source_check.exit_code == 0
+                assert source_check.stdout is not None
+                assert "source-alive" in source_check.stdout
+
+                cloned_check = await manager.exec(cloned_id, ["echo", "cloned-alive"])
+                assert cloned_check.exit_code == 0
+                assert cloned_check.stdout is not None
+                assert "cloned-alive" in cloned_check.stdout
 
                 # Verify command is actually running in cloned container
                 cloned_cmdline_result = await manager.exec(
@@ -487,7 +514,6 @@ class TestContainerCloning:
         self,
         test_image: str,
         docker_client_type: str,
-        docker_client: AbstractDockerClient | None,
         create_manager_config,
     ):
         """Test cloning multi-container setup clones network too."""
@@ -527,8 +553,9 @@ class TestContainerCloning:
                 assert cloned_state.network_id is not None
 
                 # Verify cloned containers can communicate on new network
-                # (Use Docker API to verify network attachment)
-                assert docker_client is not None
+                # (Use manager's internal Docker client to verify network attachment)
+                assert manager._batch_state is not None
+                docker_client = manager._batch_state.docker_client
                 clone_agent = await docker_client.get_container(cloned_state.agent_container_id)
                 clone_info = await clone_agent.show()
                 networks = clone_info["NetworkSettings"]["Networks"]
@@ -538,7 +565,6 @@ class TestContainerCloning:
         self,
         test_image: str,
         docker_client_type: str,
-        docker_client: AbstractDockerClient | None,
         create_manager_config,
     ):
         """Test that cloning cleanup removes temporary images."""
@@ -564,28 +590,33 @@ class TestContainerCloning:
                     cloned_state = await manager.clone_sandbox_state(source_state)
                     cloned_states.append(cloned_state)
 
-                # Verify temp images exist
-                assert docker_client is not None
-                local_client = docker_client
-                assert isinstance(local_client, LocalDockerClient)
-                images = await local_client._docker.images.list()
-                image_tags = [tag for img in images for tag in img.get("RepoTags", [])]
-                temp_images_count = sum(1 for tag in image_tags if tag and "temp-clone-" in tag)
-                assert temp_images_count >= 3
+                # Verify clones exist and are functional
+                for cloned_state in cloned_states:
+                    result = await manager.exec(
+                        cloned_state.agent_container_id,
+                        ["echo", "clone-alive"],
+                    )
+                    assert result.exit_code == 0
 
-            # After task cleanup, temp images should be gone
-            assert docker_client is not None
-            local_client = docker_client
-            assert isinstance(local_client, LocalDockerClient)
-            images = await local_client._docker.images.list()
-            image_tags = [tag for img in images for tag in img.get("RepoTags", [])]
+            # After task cleanup, verify temp images are removed
+            # Use manager's docker_client (still available in batch context)
+            assert manager._batch_state is not None
+            docker_client = manager._batch_state.docker_client
 
-            # Filter for temp images from this specific execution
-            # (may have temp images from other tests)
+            # Verify temp images from these clones are gone
             for cloned_state in cloned_states:
-                # Verify this specific clone's temp image is gone
-                temp_image_pattern = f"temp-clone-{cloned_state.execution_id}"
-                assert not any(temp_image_pattern in (tag or "") for tag in image_tags)
+                temp_image_tag = f"temp-clone-{cloned_state.execution_id}-agent"
+                image_existed = False
+
+                try:
+                    await docker_client.inspect_image(temp_image_tag)
+                    # If we get here, image still exists - that's bad!
+                    image_existed = True
+                except Exception:
+                    # Image doesn't exist - that's what we want!
+                    pass
+
+                assert not image_existed, f"Temp image {temp_image_tag} should have been removed"
 
 
 # ==================== Concurrent Execution Tests ====================
@@ -698,10 +729,18 @@ class TestImageBuilding:
         self,
         test_image: str,
         docker_client_type: str,
-        docker_client: AbstractDockerClient | None,
         create_manager_config,
+        docker_client,
     ):
         """Test building an image from a Dockerfile using BuildImageSpec."""
+        # PRE-TEST CLEANUP: Remove any existing test image
+        # Use docker_client fixture ONLY for pre-cleanup
+        try:
+            await docker_client.delete_image("prompt-siren-test-build:latest", force=True)
+        except Exception:
+            pass  # Image might not exist, that's fine
+
+        # Now create manager and run the actual test
         config = create_manager_config(
             docker_client_type, network_enabled=False, test_images=test_image
         )
@@ -721,25 +760,8 @@ class TestImageBuilding:
             network_config=None,
         )
 
-        # Cleanup any existing test image
-        assert docker_client is not None
-        local_client = docker_client
-        assert isinstance(local_client, LocalDockerClient)
-        try:
-            await local_client._docker.images.delete("prompt-siren-test-build:latest", force=True)
-        except Exception:
-            pass
-
         async with manager.setup_batch([task_setup]):
-            # Verify image was built
-            assert docker_client is not None
-            local_client = docker_client
-            assert isinstance(local_client, LocalDockerClient)
-            images = await local_client._docker.images.list()
-            image_tags = [tag for img in images for tag in img.get("RepoTags", [])]
-            assert any("prompt-siren-test-build:latest" in (tag or "") for tag in image_tags)
-
-            # Create container and verify build marker
+            # Verify image was built by using it to create a container
             async with manager.setup_task(task_setup) as sandbox_state:
                 result = await manager.exec(
                     sandbox_state.agent_container_id,
@@ -749,23 +771,28 @@ class TestImageBuilding:
                 assert result.stdout is not None
                 assert "Test build successful" in result.stdout
 
-        # Cleanup
-        assert docker_client is not None
-        local_client = docker_client
-        assert isinstance(local_client, LocalDockerClient)
-        try:
-            await local_client._docker.images.delete("prompt-siren-test-build:latest", force=True)
-        except Exception:
-            pass
+            # Cleanup using abstract interface
+            assert manager._batch_state is not None
+            await manager._batch_state.docker_client.delete_image(
+                "prompt-siren-test-build:latest", force=True
+            )
 
     async def test_build_with_build_args(
         self,
         test_image: str,
         docker_client_type: str,
-        docker_client: AbstractDockerClient | None,
         create_manager_config,
+        docker_client,
     ):
         """Test building an image with build_args and custom dockerfile_path."""
+        # PRE-TEST CLEANUP: Remove any existing test image
+        # Use docker_client fixture ONLY for pre-cleanup
+        try:
+            await docker_client.delete_image("prompt-siren-test-build-args:latest", force=True)
+        except Exception:
+            pass  # Image might not exist, that's fine
+
+        # Now create manager and run the actual test
         config = create_manager_config(
             docker_client_type, network_enabled=False, test_images=test_image
         )
@@ -787,17 +814,6 @@ class TestImageBuilding:
             network_config=None,
         )
 
-        # Cleanup any existing test image
-        assert docker_client is not None
-        local_client = docker_client
-        assert isinstance(local_client, LocalDockerClient)
-        try:
-            await local_client._docker.images.delete(
-                "prompt-siren-test-build-args:latest", force=True
-            )
-        except Exception:
-            pass
-
         async with manager.setup_batch([task_setup]):
             async with manager.setup_task(task_setup) as sandbox_state:
                 # Verify build arg was used
@@ -809,25 +825,28 @@ class TestImageBuilding:
                 assert result.stdout is not None
                 assert "custom_value" in result.stdout
 
-        # Cleanup
-        assert docker_client is not None
-        local_client = docker_client
-        assert isinstance(local_client, LocalDockerClient)
-        try:
-            await local_client._docker.images.delete(
+            # Cleanup using abstract interface
+            assert manager._batch_state is not None
+            await manager._batch_state.docker_client.delete_image(
                 "prompt-siren-test-build-args:latest", force=True
             )
-        except Exception:
-            pass
 
     async def test_mixed_pull_and_build_specs(
         self,
         test_image: str,
         docker_client_type: str,
-        docker_client: AbstractDockerClient | None,
         create_manager_config,
+        docker_client,
     ):
         """Test using both PullImageSpec and BuildImageSpec in the same batch."""
+        # PRE-TEST CLEANUP: Remove any existing test image
+        # Use docker_client fixture ONLY for pre-cleanup
+        try:
+            await docker_client.delete_image("prompt-siren-test-mixed:latest", force=True)
+        except Exception:
+            pass  # Image might not exist, that's fine
+
+        # Now create manager and run the actual test
         config = create_manager_config(
             docker_client_type, network_enabled=False, test_images=test_image
         )
@@ -857,15 +876,6 @@ class TestImageBuilding:
             ),
         ]
 
-        # Cleanup any existing test image
-        assert docker_client is not None
-        local_client = docker_client
-        assert isinstance(local_client, LocalDockerClient)
-        try:
-            await local_client._docker.images.delete("prompt-siren-test-mixed:latest", force=True)
-        except Exception:
-            pass
-
         async with manager.setup_batch(task_setups):
             # Create containers from both images
             async with manager.setup_task(task_setups[0]) as pulled_state:
@@ -884,14 +894,11 @@ class TestImageBuilding:
                 assert result2.stdout is not None
                 assert "Test build successful" in result2.stdout
 
-        # Cleanup
-        assert docker_client is not None
-        local_client = docker_client
-        assert isinstance(local_client, LocalDockerClient)
-        try:
-            await local_client._docker.images.delete("prompt-siren-test-mixed:latest", force=True)
-        except Exception:
-            pass
+            # Cleanup using abstract interface
+            assert manager._batch_state is not None
+            await manager._batch_state.docker_client.delete_image(
+                "prompt-siren-test-mixed:latest", force=True
+            )
 
 
 # ==================== Multi-Stage Build Tests ====================
@@ -905,18 +912,25 @@ class TestMultiStageBuild:
         self,
         multistage_test_images: list[str],
         docker_client_type: str,
-        docker_client: AbstractDockerClient | None,
         create_manager_config,
+        docker_client,
     ):
         """Test that multi-stage build creates all three stages correctly."""
+        base_tag = "test-multistage-base:latest"
+        env_tag = "test-multistage-env:latest"
+        instance_tag = "test-multistage-instance:latest"
+
+        # PRE-TEST CLEANUP: Remove any existing images
+        # Use docker_client fixture ONLY for pre-cleanup
+        for tag in [base_tag, env_tag, instance_tag]:
+            with contextlib.suppress(Exception):
+                await docker_client.delete_image(tag, force=True)
+
+        # Now create manager and run the actual test
         config = create_manager_config(
             docker_client_type, network_enabled=False, test_images=multistage_test_images
         )
         manager = DockerSandboxManager(config)
-
-        base_tag = "test-multistage-base:latest"
-        env_tag = "test-multistage-env:latest"
-        instance_tag = "test-multistage-instance:latest"
 
         stages = [
             BuildStage(
@@ -948,29 +962,8 @@ class TestMultiStageBuild:
             network_config=None,
         )
 
-        # Cleanup any existing images
-        assert docker_client is not None
-        local_client = docker_client
-        assert isinstance(local_client, LocalDockerClient)
-        for tag in [base_tag, env_tag, instance_tag]:
-            try:
-                await local_client._docker.images.delete(tag, force=True)
-            except Exception:  # noqa: PERF203
-                pass
-
         async with manager.setup_batch([task_setup]):
-            # Verify all three images were created
-            assert docker_client is not None
-            local_client = docker_client
-            assert isinstance(local_client, LocalDockerClient)
-            images = await local_client._docker.images.list()
-            image_tags = [tag for img in images for tag in img.get("RepoTags", [])]
-
-            assert any(base_tag in (tag or "") for tag in image_tags)
-            assert any(env_tag in (tag or "") for tag in image_tags)
-            assert any(instance_tag in (tag or "") for tag in image_tags)
-
-            # Create container and verify all stages executed
+            # Verify all stages were built by creating a container and checking markers
             async with manager.setup_task(task_setup) as sandbox_state:
                 container_id = sandbox_state.agent_container_id
 
@@ -992,32 +985,35 @@ class TestMultiStageBuild:
                 assert result.stdout is not None
                 assert "Instance ready" in result.stdout
 
-        # Cleanup
-        assert docker_client is not None
-        local_client = docker_client
-        assert isinstance(local_client, LocalDockerClient)
-        for tag in [base_tag, env_tag, instance_tag]:
-            try:
-                await local_client._docker.images.delete(tag, force=True)
-            except Exception:  # noqa: PERF203
-                pass
+            # Cleanup using abstract interface
+            assert manager._batch_state is not None
+            docker_client = manager._batch_state.docker_client
+            for tag in [base_tag, env_tag, instance_tag]:
+                await docker_client.delete_image(tag, force=True)
 
     async def test_multi_stage_build_caching(
         self,
         multistage_test_images: list[str],
         docker_client_type: str,
-        docker_client: AbstractDockerClient | None,
         create_manager_config,
+        docker_client,
     ):
         """Test that multi-stage build properly caches intermediate stages."""
+        base_tag = "test-multistage-cache-base:latest"
+        env_tag = "test-multistage-cache-env:latest"
+        instance_tag = "test-multistage-cache-instance:latest"
+
+        # PRE-TEST CLEANUP: Remove any existing images
+        # Use docker_client fixture ONLY for pre-cleanup
+        for tag in [base_tag, env_tag, instance_tag]:
+            with contextlib.suppress(Exception):
+                await docker_client.delete_image(tag, force=True)
+
+        # Now create manager and run the actual test
         config = create_manager_config(
             docker_client_type, network_enabled=False, test_images=multistage_test_images
         )
         manager = DockerSandboxManager(config)
-
-        base_tag = "test-multistage-cache-base:latest"
-        env_tag = "test-multistage-cache-env:latest"
-        instance_tag = "test-multistage-cache-instance:latest"
 
         stages = [
             BuildStage(
@@ -1043,16 +1039,6 @@ class TestMultiStageBuild:
         container_spec = ContainerSpec(image_spec=multi_stage_spec)
         agent_container = ContainerSetup(name="agent", spec=container_spec)
 
-        # Cleanup any existing images
-        assert docker_client is not None
-        local_client = docker_client
-        assert isinstance(local_client, LocalDockerClient)
-        for tag in [base_tag, env_tag, instance_tag]:
-            try:
-                await local_client._docker.images.delete(tag, force=True)
-            except Exception:  # noqa: PERF203
-                pass
-
         # First build - all stages should be built
         task_setup1 = TaskSetup(
             task_id="cache-test-1",
@@ -1062,22 +1048,17 @@ class TestMultiStageBuild:
         )
 
         async with manager.setup_batch([task_setup1]):
-            # Verify all images created
-            assert docker_client is not None
-            local_client = docker_client
-            assert isinstance(local_client, LocalDockerClient)
-            images = await local_client._docker.images.list()
-            image_tags = [tag for img in images for tag in img.get("RepoTags", [])]
+            # Verify all images created by inspecting them
+            assert manager._batch_state is not None
+            docker_client = manager._batch_state.docker_client
 
-            assert any(base_tag in (tag or "") for tag in image_tags)
-            assert any(env_tag in (tag or "") for tag in image_tags)
-            assert any(instance_tag in (tag or "") for tag in image_tags)
+            # Images should exist (inspect_image would raise if not)
+            await docker_client.inspect_image(base_tag)
+            await docker_client.inspect_image(env_tag)
+            await docker_client.inspect_image(instance_tag)
 
-        # Delete only instance image
-        assert docker_client is not None
-        local_client = docker_client
-        assert isinstance(local_client, LocalDockerClient)
-        await local_client._docker.images.delete(instance_tag, force=True)
+            # Delete only instance image
+            await docker_client.delete_image(instance_tag, force=True)
 
         # Second build - base and env should be cached
         task_setup2 = TaskSetup(
@@ -1088,16 +1069,13 @@ class TestMultiStageBuild:
         )
 
         async with manager.setup_batch([task_setup2]):
-            # Verify all images exist again
-            assert docker_client is not None
-            local_client = docker_client
-            assert isinstance(local_client, LocalDockerClient)
-            images = await local_client._docker.images.list()
-            image_tags = [tag for img in images for tag in img.get("RepoTags", [])]
+            # Verify all images exist again by inspecting them
+            assert manager._batch_state is not None
+            docker_client = manager._batch_state.docker_client
 
-            assert any(base_tag in (tag or "") for tag in image_tags)
-            assert any(env_tag in (tag or "") for tag in image_tags)
-            assert any(instance_tag in (tag or "") for tag in image_tags)
+            await docker_client.inspect_image(base_tag)
+            await docker_client.inspect_image(env_tag)
+            await docker_client.inspect_image(instance_tag)
 
             # Verify functionality
             async with manager.setup_task(task_setup2) as sandbox_state:
@@ -1109,33 +1087,34 @@ class TestMultiStageBuild:
                 assert result.stdout is not None
                 assert "Instance ready" in result.stdout
 
-        # Cleanup
-        assert docker_client is not None
-        local_client = docker_client
-        assert isinstance(local_client, LocalDockerClient)
-        for tag in [base_tag, env_tag, instance_tag]:
-            try:
-                await local_client._docker.images.delete(tag, force=True)
-            except Exception:  # noqa: PERF203
-                pass
+            # Cleanup using abstract interface
+            for tag in [base_tag, env_tag, instance_tag]:
+                await docker_client.delete_image(tag, force=True)
 
     async def test_shared_base_and_env_stages(
         self,
         multistage_test_images: list[str],
         docker_client_type: str,
-        docker_client: AbstractDockerClient | None,
         create_manager_config,
+        docker_client,
     ):
         """Test multiple instances sharing base and env stages."""
-        config = create_manager_config(
-            docker_client_type, network_enabled=False, test_images=multistage_test_images
-        )
-        manager = DockerSandboxManager(config)
-
         base_tag = "test-shared-base:latest"
         env_tag = "test-shared-env:latest"
         instance1_tag = "test-shared-instance1:latest"
         instance2_tag = "test-shared-instance2:latest"
+
+        # PRE-TEST CLEANUP: Remove any existing images
+        # Use docker_client fixture ONLY for pre-cleanup
+        for tag in [base_tag, env_tag, instance1_tag, instance2_tag]:
+            with contextlib.suppress(Exception):
+                await docker_client.delete_image(tag, force=True)
+
+        # Now create manager and run the actual test
+        config = create_manager_config(
+            docker_client_type, network_enabled=False, test_images=multistage_test_images
+        )
+        manager = DockerSandboxManager(config)
 
         # Two specs sharing base and env
         spec1 = MultiStageBuildImageSpec(
@@ -1203,31 +1182,16 @@ class TestMultiStageBuild:
             ),
         ]
 
-        # Cleanup
-        assert docker_client is not None
-        local_client = docker_client
-        assert isinstance(local_client, LocalDockerClient)
-        for tag in [base_tag, env_tag, instance1_tag, instance2_tag]:
-            try:
-                await local_client._docker.images.delete(tag, force=True)
-            except Exception:  # noqa: PERF203
-                pass
-
         async with manager.setup_batch(task_setups):
-            # Verify all images created
-            assert docker_client is not None
-            local_client = docker_client
-            assert isinstance(local_client, LocalDockerClient)
-            images = await local_client._docker.images.list()
-            image_tags = [tag for img in images for tag in img.get("RepoTags", [])]
+            # Verify all images created by inspecting them
+            assert manager._batch_state is not None
+            docker_client = manager._batch_state.docker_client
 
-            # Base and env should exist (built once)
-            assert any(base_tag in (tag or "") for tag in image_tags)
-            assert any(env_tag in (tag or "") for tag in image_tags)
-
-            # Both instances should exist
-            assert any(instance1_tag in (tag or "") for tag in image_tags)
-            assert any(instance2_tag in (tag or "") for tag in image_tags)
+            # All images should exist
+            await docker_client.inspect_image(base_tag)
+            await docker_client.inspect_image(env_tag)
+            await docker_client.inspect_image(instance1_tag)
+            await docker_client.inspect_image(instance2_tag)
 
             # Verify both work
             async with manager.setup_task(task_setups[0]) as state1:
@@ -1244,15 +1208,9 @@ class TestMultiStageBuild:
                 )
                 assert result.exit_code == 0
 
-        # Cleanup
-        assert docker_client is not None
-        local_client = docker_client
-        assert isinstance(local_client, LocalDockerClient)
-        for tag in [base_tag, env_tag, instance1_tag, instance2_tag]:
-            try:
-                await local_client._docker.images.delete(tag, force=True)
-            except Exception:  # noqa: PERF203
-                pass
+            # Cleanup using abstract interface
+            for tag in [base_tag, env_tag, instance1_tag, instance2_tag]:
+                await docker_client.delete_image(tag, force=True)
 
 
 # ==================== Stdin Handling Tests ====================


### PR DESCRIPTION
Summary: We were mistakenly setting up an independent `docker_client` for the integration tests in the conftest. However, we should be reusing the client that the `SandboxManager` has under the hood as the two might have different states (e.g. borrow different virtual machines on remote Docker services).

Differential Revision:
D88953657

Privacy Context Container: L1394073


