### PR TITLE
Fix null task_span crash in persistence

### DIFF
--- a/src/prompt_siren/job/persistence.py
+++ b/src/prompt_siren/job/persistence.py
@@ -139,7 +139,7 @@ class JobPersistence:
         exception_info = ExceptionInfo.from_exception(exception) if exception else None
 
         # Get trace context
-        span_context = task_span.get_span_context()
+        span_context = task_span.get_span_context() if task_span is not None else None
         trace_id = format(span_context.trace_id, "032x") if span_context else None
         span_id = format(span_context.span_id, "016x") if span_context else None
 
@@ -243,7 +243,7 @@ class JobPersistence:
         exception_info = ExceptionInfo.from_exception(exception) if exception else None
 
         # Get trace context
-        span_context = task_span.get_span_context()
+        span_context = task_span.get_span_context() if task_span is not None else None
         trace_id = format(span_context.trace_id, "032x") if span_context else None
         span_id = format(span_context.span_id, "016x") if span_context else None
 


### PR DESCRIPTION
Summary:
task_span can be None when the telemetry context is unavailable.
Guard the get_span_context() call to prevent AttributeError.

Differential Revision: D99754218


