### PR TITLE
chore: declare contents: read on the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 env:
   UV_VERSION: 0.9.18
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
CI workflow does pure build + test. `tests.yml` in this repo already declares workflow-level `contents: read`; this brings `ci.yml` in line.